### PR TITLE
rpc/eth: add roundParamFromBlockNum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Build binary.
+oasis-evm-web3-gateway
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
 	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/storage"
 )
@@ -172,7 +173,7 @@ func (p *psqlBackend) Index(
 	blockHash ethcommon.Hash,
 	txs []*types.UnverifiedTransaction,
 ) error {
-	//block round <-> block hash
+	// block round <-> block hash
 	blockRef := &model.BlockRef{
 		Round: round,
 		Hash:  blockHash.String(),
@@ -214,12 +215,19 @@ func (p *psqlBackend) QueryBlockRound(blockHash ethcommon.Hash) (uint64, error) 
 }
 
 func (p *psqlBackend) QueryBlockHash(round uint64) (ethcommon.Hash, error) {
-	blockHash, err := p.storage.GetBlockHash(round)
-	if err != nil {
-		p.logger.Error("Indexer error!")
-		return ethcommon.Hash{}, err
+	var blockHash string
+	var err error
+	switch round {
+	case RoundLatest:
+		blockHash, err = p.storage.GetLatestBlockHash()
+	default:
+		blockHash, err = p.storage.GetBlockHash(round)
 	}
 
+	if err != nil {
+		p.logger.Error("indexer error", "err", err)
+		return ethcommon.Hash{}, err
+	}
 	return ethcommon.HexToHash(blockHash), nil
 }
 

--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -45,9 +45,6 @@ type QueryableBackend interface {
 	// QueryTransactionRef returns block hash, round and index of the transaction.
 	QueryTransactionRef(ethTxHash string) (*model.TransactionRef, error)
 
-	// QueryTransactionByRoundAndIndex queries ethereum transaction by round and index.
-	QueryTransactionByRoundAndIndex(round uint64, index uint32) (*model.Transaction, error)
-
 	// QueryIndexedRound query continues indexed block round.
 	QueryIndexedRound() uint64
 
@@ -264,10 +261,6 @@ func (p *psqlBackend) QueryTransaction(ethTxHash ethcommon.Hash) (*model.Transac
 
 func (p *psqlBackend) QueryTransactionRef(hash string) (*model.TransactionRef, error) {
 	return p.storage.GetTransactionRef(hash)
-}
-
-func (p *psqlBackend) QueryTransactionByRoundAndIndex(round uint64, index uint32) (*model.Transaction, error) {
-	return p.storage.GetTransactionByRoundAndIndex(round, index)
 }
 
 func (p *psqlBackend) Close() {

--- a/main.go
+++ b/main.go
@@ -85,14 +85,14 @@ func runRoot(cmd *cobra.Command, args []string) {
 	// Initialize server config
 	cfg, err := conf.InitConfig("./conf/server.yml")
 	if err != nil {
-		logger.Error("failed to initialize config", err)
+		logger.Error("failed to initialize config", "err", err)
 		os.Exit(1)
 	}
 
 	// Initialize db
 	db, err := psql.InitDb(cfg)
 	if err != nil {
-		logger.Error("failed to initialize db", err)
+		logger.Error("failed to initialize db", "err", err)
 		os.Exit(1)
 	}
 

--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -5,26 +5,23 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/common/logging"
-	"github.com/oasisprotocol/oasis-core/go/common/quantity"
-	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-
-	"github.com/starfishlabs/oasis-evm-web3-gateway/indexer"
-	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
-
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
+	"github.com/starfishlabs/oasis-evm-web3-gateway/indexer"
+	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/rpc/utils"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/server"
 )
@@ -35,9 +32,7 @@ const (
 	methodCall   = "evm.Call"
 )
 
-var (
-	ErrInternalQuery = errors.New("internal query error")
-)
+var ErrInternalQuery = errors.New("internal query error")
 
 // Log is the Oasis Log.
 type Log struct {
@@ -136,7 +131,6 @@ func (api *PublicAPI) getRPCBlock(oasisBlock *block.Block) (map[string]interface
 	}
 
 	res, err := utils.ConvertToEthBlock(oasisBlock, ethTxs, logs, gasUsed)
-
 	if err != nil {
 		api.Logger.Debug("Failed to ConvertToEthBlock", "height", blockNum, "error", err.Error())
 		return nil, err
@@ -173,7 +167,6 @@ func (api *PublicAPI) GetBlockTransactionCountByNumber(blockNum ethrpc.BlockNumb
 func (api *PublicAPI) GetBalance(address common.Address, blockNrOrHash ethrpc.BlockNumberOrHash) (*hexutil.Big, error) {
 	ethmod := evm.NewV1(api.client)
 	res, err := ethmod.Balance(api.ctx, address[:])
-
 	if err != nil {
 		api.Logger.Error("Get balance failed")
 		return nil, err
@@ -229,7 +222,6 @@ func (api *PublicAPI) GetTransactionCount(ethaddr common.Address, blockNum ethrp
 	accountsMod := accounts.NewV1(api.client)
 	accountsAddr := types.NewAddressRaw(types.AddressV0Secp256k1EthContext, ethaddr[:])
 	nonce, err := accountsMod.Nonce(api.ctx, client.RoundLatest, accountsAddr)
-
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +233,6 @@ func (api *PublicAPI) GetTransactionCount(ethaddr common.Address, blockNum ethrp
 func (api *PublicAPI) GetCode(address common.Address, blockNrOrHash ethrpc.BlockNumberOrHash) (hexutil.Bytes, error) {
 	ethmod := evm.NewV1(api.client)
 	res, err := ethmod.Code(api.ctx, address[:])
-
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +279,6 @@ func (api *PublicAPI) Call(args utils.TransactionArgs, _ ethrpc.BlockNumberOrHas
 		args.To.Bytes(),
 		amount,
 		input)
-
 	if err != nil {
 		api.Logger.Error("Failed to execute SimulateCall", "error", err.Error())
 		return nil, err
@@ -518,7 +508,7 @@ func (api *PublicAPI) GetTransactionReceipt(txHash common.Hash) (map[string]inte
 		}
 	}
 	logs := logs2EthLogs(oasisLogs, txRef.Round, common.HexToHash(txRef.BlockHash), txHash, txRef.Index)
-	//blockNum:=new(big.Int).SetUint64(txRef.Round).String()
+	// blockNum:=new(big.Int).SetUint64(txRef.Round).String()
 	receipt := map[string]interface{}{
 		"status":            hexutil.Uint(status),
 		"cumulativeGasUsed": hexutil.Uint64(cumulativeGasUsed),

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -140,6 +140,17 @@ func (db *PostDb) GetBlockHash(round uint64) (string, error) {
 	return blk.Hash, nil
 }
 
+// GetLatestBlockHash queries for the block hash of the latest round.
+func (db *PostDb) GetLatestBlockHash() (string, error) {
+	blk := new(model.BlockRef)
+	err := db.Db.Model(blk).Order("round DESC").Limit(1).Select()
+	if err != nil {
+		return "", err
+	}
+
+	return blk.Hash, nil
+}
+
 // GetContinuesIndexedRound queries latest continues indexed block round.
 func (db *PostDb) GetContinuesIndexedRound() (uint64, error) {
 	indexedRound := new(model.ContinuesIndexedRound)

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-pg/pg/v10"
+
 	"github.com/starfishlabs/oasis-evm-web3-gateway/conf"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
 )
@@ -53,27 +54,6 @@ func (db *PostDb) GetTransactionRef(txHash string) (*model.TransactionRef, error
 	}
 
 	return tx, nil
-}
-
-// GetTransactionByRoundAndIndex queries ethereum transaction by round and index.
-func (db *PostDb) GetTransactionByRoundAndIndex(round uint64, index uint32) (*model.Transaction, error) {
-	txRef := new(model.TransactionRef)
-	err := db.Db.Model(txRef).
-		Where("round=? and index=?", round, index).
-		Select()
-	if err != nil {
-		return nil, err
-	}
-
-	ethTx := new(model.Transaction)
-	err = db.Db.Model(ethTx).
-		Where("hash=?", txRef.EthTxHash).
-		Select()
-	if err != nil {
-		return nil, err
-	}
-
-	return ethTx, nil
 }
 
 // GetTransaction queries ethereum transaction by hash.

--- a/storage/types.go
+++ b/storage/types.go
@@ -26,9 +26,6 @@ type Storage interface {
 	// GetTransactionRef returns block hash, round and index of the transaction.
 	GetTransactionRef(ethTxHash string) (*model.TransactionRef, error)
 
-	// GetTransactionByRoundAndIndex queries ethereum transaction by round and index.
-	GetTransactionByRoundAndIndex(round uint64, index uint32) (*model.Transaction, error)
-
 	// GetContinuesIndexedRound query continues indexed block round.
 	GetContinuesIndexedRound() (uint64, error)
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -20,6 +20,9 @@ type Storage interface {
 	// GetBlockHash queries block hash by block round.
 	GetBlockHash(round uint64) (string, error)
 
+	// GetLatestBlockHash returns the block hash of the latest indexed round.
+	GetLatestBlockHash() (string, error)
+
 	// GetTransactionRef returns block hash, round and index of the transaction.
 	GetTransactionRef(ethTxHash string) (*model.TransactionRef, error)
 


### PR DESCRIPTION
fixes #9 

I've added a method `roundParamFromBlockNum` based on the description in #9 

- `LatestBlockNumber` -> `RoundLatest` -- issue said `0`, but I think that was mistaken
- `PendingBlockNumber` -> `RoundLatest` -- using the same as latest, as suggested in the issue
- `EarliestBlockNumber` -> `1` -- using the option with the simplest implementation for now

The issue said that 1 is the earliest, and I'm taking its word for it. I actually don't know what round "0" would mean on Oasis.

The function doesn't do any validation. Zero and other negative values are casted blindly to uint64.

Some parameters that were declared as `number string` are now changed to `blockNum ethrpc.BlockNumber`, matching the rest of the file.
As I understand the type from go-ethereum, the special values should still log in a friendly way.

