### PR TITLE
rpc/eth: add GetLogs

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -14,6 +15,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
@@ -91,7 +93,7 @@ func (api *PublicAPI) roundParamFromBlockNum(blockNum ethrpc.BlockNumber) (uint6
 	}
 }
 
-func (api *PublicAPI) getRPCBlock(oasisBlock *block.Block) (map[string]interface{}, error) {
+func (api *PublicAPI) getRPCBlockData(oasisBlock *block.Block) (uint64, ethtypes.Transactions, uint64, []*ethtypes.Log, error) {
 	bhash, _ := oasisBlock.Header.IORoot.MarshalBinary()
 	blockNum := oasisBlock.Header.Round
 	ethTxs := ethtypes.Transactions{}
@@ -100,7 +102,7 @@ func (api *PublicAPI) getRPCBlock(oasisBlock *block.Block) (map[string]interface
 	txResults, err := api.client.GetTransactionsWithResults(api.ctx, blockNum)
 	if err != nil {
 		api.Logger.Error("Failed to get transaction results", "number", blockNum, "error", err.Error())
-		return nil, err
+		return 0, nil, 0, nil, err
 	}
 
 	for txIndex, item := range txResults {
@@ -137,6 +139,14 @@ func (api *PublicAPI) getRPCBlock(oasisBlock *block.Block) (map[string]interface
 		}
 
 		logs = logs2EthLogs(oasisLogs, oasisBlock.Header.Round, common.BytesToHash(bhash), ethTx.Hash(), uint32(txIndex))
+	}
+	return blockNum, ethTxs, gasUsed, logs, nil
+}
+
+func (api *PublicAPI) getRPCBlock(oasisBlock *block.Block) (map[string]interface{}, error) {
+	blockNum, ethTxs, gasUsed, logs, err := api.getRPCBlockData(oasisBlock)
+	if err != nil {
+		return nil, err
 	}
 
 	res, err := utils.ConvertToEthBlock(oasisBlock, ethTxs, logs, gasUsed)
@@ -633,6 +643,61 @@ func (api *PublicAPI) GetTransactionReceipt(txHash common.Hash) (map[string]inte
 	}
 	api.Logger.Debug("eth_getTransactionReceipt end")
 	return receipt, nil
+}
+
+func (api *PublicAPI) GetLogs(filter ethereum.FilterQuery) ([]*ethtypes.Log, error) {
+	startRoundInclusive := client.RoundLatest
+	endRoundInclusive := client.RoundLatest
+	if filter.BlockHash != nil {
+		round, err := api.backend.QueryBlockRound(*filter.BlockHash)
+		if err != nil {
+			return nil, fmt.Errorf("query block round: %w", err)
+		}
+		startRoundInclusive = round
+		endRoundInclusive = round
+	} else {
+		if filter.FromBlock != nil {
+			round, err := api.roundParamFromBlockNum(ethrpc.BlockNumber(filter.FromBlock.Int64()))
+			if err != nil {
+				return nil, fmt.Errorf("convert from block number to round: %w", err)
+			}
+			startRoundInclusive = round
+		}
+		if filter.ToBlock != nil {
+			round, err := api.roundParamFromBlockNum(ethrpc.BlockNumber(filter.ToBlock.Int64()))
+			if err != nil {
+				return nil, fmt.Errorf("convert to block number to round: %w", err)
+			}
+			endRoundInclusive = round
+		}
+	}
+
+	// Warning: this is unboundedly expensive
+	var ethLogs []*ethtypes.Log
+	for round := startRoundInclusive; /* see explicit break */; round++ {
+		block, err := api.client.GetBlock(api.ctx, round)
+		if err != nil {
+			if errors.Is(err, roothash.ErrNotFound) && round != client.RoundLatest && endRoundInclusive == client.RoundLatest {
+				// We've walked up to the latest round
+				break
+			}
+			return nil, fmt.Errorf("get block %d: %w", round, err)
+		}
+		_, _, _, blockLogs, err := api.getRPCBlockData(block)
+		if err != nil {
+			return nil, fmt.Errorf("convert block %d to rpc block: %w", block.Header.Round, err)
+		}
+
+		// TODO: filter addresses and topics
+
+		ethLogs = append(ethLogs, blockLogs...)
+
+		if round == endRoundInclusive {
+			break
+		}
+	}
+
+	return ethLogs, nil
 }
 
 // logs2EthLogs casts the Oasis Logs to a slice of Ethereum Logs.


### PR DESCRIPTION
for #10 

This splits out most of getRPCBlock into a getRPCBlockData method, which gives the logs. There might be some wasted work to get the information other than the logs. Feel free to tighten up the splitting in later work.

I wrote up some logic to walk through the block boundaries. but it's not tested and it's coupled with some expensive query stuff, so it's going to be hard to verify.

In this preliminary implementation, we don't have all the filtering features, notably for addresses and topics.

In this implementation, it's an error to request any blocks that don't exist yet. You don't get the logs from existing blocks when that error occurs. I don't know if that's consistent with the spec. Going from an earlier block up to "latest" is intended to work though.

