### PR TITLE
estimateGas: append dummy signer and set ethereum caller address

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/go-pg/pg/v10 v10.10.6
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/oasisprotocol/oasis-core/go v0.2103.4
-	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.1-0.20211030201836-b3f4c44af122
+	github.com/oasisprotocol/oasis-core/go v0.2103.5
+	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.1-0.20211109100622-e6e6ec6d63e1
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -974,10 +974,10 @@ github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84 h1:VG
 github.com/oasisprotocol/curve25519-voi v0.0.0-20210716083614-f38f8e8b0b84/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956 h1:etZXZf8f2xLJFivW4tTg87nSV3KLszQ7oYot3UNcmF0=
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
-github.com/oasisprotocol/oasis-core/go v0.2103.4 h1:LOdXcZkwOdMrBT8BHkI6ik2WFJKpZ/f6Kb4PXB2TXh4=
-github.com/oasisprotocol/oasis-core/go v0.2103.4/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.1-0.20211030201836-b3f4c44af122 h1:+VIcdgBAADgQ/FxB5PqkTxziRvnSdBjHE/bgMnFkrc8=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.1-0.20211030201836-b3f4c44af122/go.mod h1:+9tJZUmGpHw3lqUhYUHirxsZKj7MOFVJV20BXJq0YEo=
+github.com/oasisprotocol/oasis-core/go v0.2103.5 h1:SNxBarM++blf2DVT1MbZgOvyPL+lw7d/ecoSqf1KlpA=
+github.com/oasisprotocol/oasis-core/go v0.2103.5/go.mod h1:X8I4m5T7qlEmFR0nLTE9Fwm6HKIuVlrZ8BBmBIxkCKk=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.1-0.20211109100622-e6e6ec6d63e1 h1:6jLhe30SNXwCeo2gDUt4h85Q0SPJKqAjUqBJXB6ZmnA=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.1.1-0.20211109100622-e6e6ec6d63e1/go.mod h1:hEKtwXHKUVH+/fL/jlYqa8FyTVzp4lLmi/PtsiAlDb4=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=


### PR DESCRIPTION
Fixes for estimate gas:
- remove unneeded gas and fees in the estimate transactions
- appends a dummy auth signature to the unsigned transactions as otherwise the estimations are underestimated
- uses eth address in `EstimateGasForCaller` (needs: https://github.com/oasisprotocol/oasis-sdk/pull/617) 