### PR TITLE
config: use viper for unmarshal and add log configuration

### DIFF
--- a/conf/config_test.go
+++ b/conf/config_test.go
@@ -2,16 +2,12 @@ package conf
 
 import (
 	"fmt"
-	"log"
 	"testing"
 )
 
 func TestInitConfig(t *testing.T) {
-	cfg, err := InitConfig("server.yml")
-	if err != nil {
-		log.Fatalln(err)
-	}
-	fmt.Printf("host=%v, port=%v, db=%v\n", cfg.PostDb.Host, cfg.PostDb.Port, cfg.PostDb.Db)
-	fmt.Printf("user=%v, password=%v\n", cfg.PostDb.User, cfg.PostDb.Password)
-	fmt.Printf("timeout=%v\n", cfg.PostDb.Timeout)
+	cfg := InitConfig("server.yml")
+	fmt.Printf("host=%v, port=%v, db=%v\n", cfg.Database.Host, cfg.Database.Port, cfg.Database.Db)
+	fmt.Printf("user=%v, password=%v\n", cfg.Database.User, cfg.Database.Password)
+	fmt.Printf("timeout=%v\n", cfg.Database.Timeout)
 }

--- a/conf/server.yml
+++ b/conf/server.yml
@@ -1,9 +1,13 @@
 runtime_id: "8000000000000000000000000000000000000000000000000000000000000000"
 node_address: "unix:/tmp/eth-runtime-test/net-runner/network/client-0/internal.sock"
-enable_pruing: false 
+enable_pruning: false
 pruning_step: 100000
 
-postdb:
+log:
+  level: debug
+  format: json
+
+database:
   host: "127.0.0.1"
   port: 5432
   db: "postgres"
@@ -19,7 +23,3 @@ gateway:
   ws:
     host: "localhost"
     port: 8546
-
-
-
-

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.41.0
-	gopkg.in/yaml.v2 v2.4.0
 )

--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -293,7 +293,7 @@ func (p *psqlBackend) Close() {
 func newPsqlBackend(runtimeID common.Namespace, storage storage.Storage) (Backend, error) {
 	b := &psqlBackend{
 		runtimeID:         runtimeID,
-		logger:            logging.GetLogger("gateway/indexer/backend"),
+		logger:            logging.GetLogger("indexer"),
 		storage:           storage,
 		indexedRoundMutex: new(sync.Mutex),
 	}

--- a/main.go
+++ b/main.go
@@ -44,19 +44,32 @@ func main() {
 	rootCmd.Execute()
 }
 
-func runRoot(cmd *cobra.Command, args []string) {
-	// Initialize logging.
-	if err := logging.Initialize(os.Stdout, logging.FmtLogfmt, logging.LevelDebug, nil); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Unable to initialize logging: %v\n", err)
-		os.Exit(1)
+func initLogging(log *conf.LogConfig) error {
+	w := os.Stdout
+	format := logging.FmtLogfmt
+	level := logging.LevelDebug
+	if log.File != "" {
+		var err error
+		if w, err = os.OpenFile(log.File, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600); err != nil {
+			return fmt.Errorf("opening log file: %w", err)
+		}
+	}
+	if err := format.Set(log.Format); err != nil {
+		return err
+	}
+	if err := level.Set(log.Level); err != nil {
+		return err
 	}
 
+	return logging.Initialize(w, format, level, nil)
+}
+
+func runRoot(cmd *cobra.Command, args []string) {
 	// Initialize server config
-	cfg, err := conf.InitConfig(configFile)
-	if err != nil {
-		logger.Error("failed to initialize config", "err", err)
-		os.Exit(1)
-	}
+	cfg := conf.InitConfig(configFile)
+	// Initialize logging.
+	err := initLogging(cfg.Log)
+	cobra.CheckErr(err)
 
 	// Decode hex runtime ID into something we can use.
 	var runtimeID common.Namespace
@@ -78,7 +91,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 	rc := client.New(conn, runtimeID)
 
 	// Initialize db
-	db, err := psql.InitDb(cfg.PostDb)
+	db, err := psql.InitDb(cfg.Database)
 	if err != nil {
 		logger.Error("failed to initialize db", "err", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -33,9 +33,6 @@ var (
 	}
 )
 
-// The global logger.
-var logger = logging.GetLogger("evm-gateway")
-
 func init() {
 	rootCmd.Flags().StringVar(&configFile, "config", "./conf/server.yml", "path to the config.yml file")
 }
@@ -70,6 +67,8 @@ func runRoot(cmd *cobra.Command, args []string) {
 	// Initialize logging.
 	err := initLogging(cfg.Log)
 	cobra.CheckErr(err)
+
+	logger := logging.GetLogger("main")
 
 	// Decode hex runtime ID into something we can use.
 	var runtimeID common.Namespace
@@ -112,7 +111,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 		logger.Error("failed to create web3", err)
 		os.Exit(1)
 	}
-	w3.RegisterAPIs(rpc.GetRPCAPIs(context.Background(), rc, logger, backend, cfg.Gateway))
+	w3.RegisterAPIs(rpc.GetRPCAPIs(context.Background(), rc, backend, cfg.Gateway))
 
 	svr := server.Server{
 		Config: cfg,

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -18,7 +18,6 @@ import (
 func GetRPCAPIs(
 	ctx context.Context,
 	client client.RuntimeClient,
-	logger *logging.Logger,
 	backend indexer.Backend,
 	config *conf.GatewayConfig,
 ) []ethRpc.API {
@@ -40,7 +39,7 @@ func GetRPCAPIs(
 		ethRpc.API{
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   eth.NewPublicAPI(ctx, client, logger, config.ChainId, backend),
+			Service:   eth.NewPublicAPI(ctx, client, logging.GetLogger("eth_rpc"), config.ChainId, backend),
 			Public:    true,
 		},
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -57,7 +57,7 @@ var (
 	ErrServerRunning = errors.New("web3 gateway server already running")
 )
 
-func timeoutsFromCfg(cfg *conf.HttpTimeouts) rpc.HTTPTimeouts {
+func timeoutsFromCfg(cfg *conf.HTTPTimeouts) rpc.HTTPTimeouts {
 	timeouts := rpc.DefaultHTTPTimeouts
 	if cfg != nil {
 		if cfg.Idle != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -3,11 +3,10 @@ package server
 import (
 	"errors"
 	"fmt"
-	"os"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
 
 	"github.com/starfishlabs/oasis-evm-web3-gateway/conf"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/storage"
@@ -34,7 +33,7 @@ func (s *Server) Close() error {
 // Web3Gateway is a container on which services can be registered.
 type Web3Gateway struct {
 	config *conf.GatewayConfig
-	log    log.Logger
+	logger *logging.Logger
 
 	stop          chan struct{} // Channel to wait for termination notifications
 	startStopLock sync.Mutex    // Start/Stop are protected by an additional lock
@@ -79,12 +78,9 @@ func New(conf *conf.GatewayConfig) (*Web3Gateway, error) {
 		return nil, fmt.Errorf("missing gateway config")
 	}
 
-	logger := log.New()
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stdout, log.LogfmtFormat())))
-
 	server := &Web3Gateway{
 		config: conf,
-		log:    logger,
+		logger: logging.GetLogger("gateway"),
 		stop:   make(chan struct{}),
 	}
 
@@ -98,10 +94,10 @@ func New(conf *conf.GatewayConfig) (*Web3Gateway, error) {
 
 	// Configure RPC servers.
 	if conf.Http != nil {
-		server.http = newHTTPServer(server.log, timeoutsFromCfg(conf.Http.Timeouts))
+		server.http = newHTTPServer(server.logger.With("server", "http"), timeoutsFromCfg(conf.Http.Timeouts))
 	}
 	if conf.WS != nil {
-		server.ws = newHTTPServer(server.log, timeoutsFromCfg(conf.WS.Timeouts))
+		server.ws = newHTTPServer(server.logger.With("server", "ws"), timeoutsFromCfg(conf.WS.Timeouts))
 	}
 
 	return server, nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/starfishlabs/oasis-evm-web3-gateway/conf"
@@ -16,7 +17,7 @@ import (
 
 func createServer(t *testing.T, httpPort, wsPort int) *Web3Gateway {
 	conf := &conf.GatewayConfig{
-		Http: &conf.GatewayHttpConfig{
+		Http: &conf.GatewayHTTPConfig{
 			Host: "127.0.0.1",
 			Port: httpPort,
 		},
@@ -25,7 +26,7 @@ func createServer(t *testing.T, httpPort, wsPort int) *Web3Gateway {
 			Port: wsPort,
 		},
 	}
-	server, err := New(conf)
+	server, err := New(conf, logging.GetLogger("test"))
 	if err != nil {
 		t.Fatalf("could not create a new node: %v", err)
 	}
@@ -137,8 +138,8 @@ func (test rpcPrefixTest) check(t *testing.T, server *Web3Gateway) {
 	httpBase := "http://" + server.http.listenAddr()
 	wsBase := "ws://" + server.http.listenAddr()
 
-	if server.WSEndpoint() != wsBase+test.wsPrefix {
-		t.Errorf("Error: node has wrong WSEndpoint %q", server.WSEndpoint())
+	if server.ws.endpoint != wsBase+test.wsPrefix {
+		t.Errorf("Error: node has wrong WSEndpoint %q", server.ws.endpoint)
 	}
 
 	for _, path := range test.wantHTTP {
@@ -210,13 +211,17 @@ func TestServerRPCPrefix(t *testing.T) {
 		test := test
 		name := fmt.Sprintf("http=%s ws=%s", test.httpPrefix, test.wsPrefix)
 		t.Run(name, func(t *testing.T) {
-			cfg := &Config{
-				HTTPHost:       "127.0.0.1",
-				HTTPPathPrefix: test.httpPrefix,
-				WSHost:         "127.0.0.1",
-				WSPathPrefix:   test.wsPrefix,
+			cfg := &conf.GatewayConfig{
+				Http: &conf.GatewayHTTPConfig{
+					Host:       "127.0.0.1",
+					PathPrefix: test.httpPrefix,
+				},
+				WS: &conf.GatewayWSConfig{
+					Host:       "127.0.0.1",
+					PathPrefix: test.wsPrefix,
+				},
 			}
-			server, err := New(cfg)
+			server, err := New(cfg, logging.GetLogger("test"))
 			if err != nil {
 				t.Fatal("can't create server:", err)
 			}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
-	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/starfishlabs/oasis-evm-web3-gateway/conf"
@@ -26,7 +25,7 @@ func createServer(t *testing.T, httpPort, wsPort int) *Web3Gateway {
 			Port: wsPort,
 		},
 	}
-	server, err := New(conf, logging.GetLogger("test"))
+	server, err := New(conf)
 	if err != nil {
 		t.Fatalf("could not create a new node: %v", err)
 	}
@@ -221,7 +220,7 @@ func TestServerRPCPrefix(t *testing.T) {
 					PathPrefix: test.wsPrefix,
 				},
 			}
-			server, err := New(cfg, logging.GetLogger("test"))
+			server, err := New(cfg)
 			if err != nil {
 				t.Fatal("can't create server:", err)
 			}

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -17,7 +17,7 @@ type PostDb struct {
 }
 
 // InitDb creates postgresql db instance
-func InitDb(cfg *conf.PostDbConfig) (*PostDb, error) {
+func InitDb(cfg *conf.DatabaseConfig) (*PostDb, error) {
 	if cfg == nil {
 		return nil, errors.New("nil configuration")
 	}

--- a/storage/psql/psql_test.go
+++ b/storage/psql/psql_test.go
@@ -14,11 +14,8 @@ import (
 func TestInitPostDb(t *testing.T) {
 	require := require.New(t)
 
-	cfg, err := conf.InitConfig("../../conf/server.yml")
-	if err != nil {
-		log.Fatal("initialize config error:", err)
-	}
-	db, err := InitDb(cfg)
+	cfg := conf.InitConfig("../../conf/server.yml")
+	db, err := InitDb(cfg.Database)
 	if err != nil {
 		log.Fatal("initialize postdb error:", err)
 	}
@@ -134,9 +131,8 @@ func TestInitPostDb(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	require := require.New(t)
 
-	cfg, err := conf.InitConfig("../../conf/server.yml")
-	require.NoError(err, "initialize config")
-	db, err := InitDb(cfg)
+	cfg := conf.InitConfig("../../conf/server.yml")
+	db, err := InitDb(cfg.Database)
 	require.NoError(err, "initialize postdb")
 
 	ir1 := &model.ContinuesIndexedRound{
@@ -171,9 +167,8 @@ func TestUpdate(t *testing.T) {
 func TestDelete(t *testing.T) {
 	require := require.New(t)
 
-	cfg, err := conf.InitConfig("../../conf/server.yml")
-	require.NoError(err, "initialize config")
-	db, err := InitDb(cfg)
+	cfg := conf.InitConfig("../../conf/server.yml")
+	db, err := InitDb(cfg.Database)
 	require.NoError(err, "initialize postdb")
 
 	require.NoError(db.Delete(new(model.BlockRef), 10), "delete")
@@ -182,9 +177,8 @@ func TestDelete(t *testing.T) {
 func TestGetBlockHash(t *testing.T) {
 	require := require.New(t)
 
-	cfg, err := conf.InitConfig("../../conf/server.yml")
-	require.NoError(err, "initialize config")
-	_, err = InitDb(cfg)
+	cfg := conf.InitConfig("../../conf/server.yml")
+	_, err := InitDb(cfg.Database)
 	require.NoError(err, "initialize postdb")
 
 	// TODO: this fails as expected as the db doesn't contain the block.
@@ -197,9 +191,8 @@ func TestGetBlockHash(t *testing.T) {
 func TestGetTransactionRef(t *testing.T) {
 	require := require.New(t)
 
-	cfg, err := conf.InitConfig("../../conf/server.yml")
-	require.NoError(err, "initialize config")
-	_, err = InitDb(cfg)
+	cfg := conf.InitConfig("../../conf/server.yml")
+	_, err := InitDb(cfg.Database)
 	require.NoError(err, "initialize postdb")
 
 	// TODO: this fails as expected as the db doesn't contain the transaction.


### PR DESCRIPTION
- use `viper` for unmarshalling configuration (closes: https://github.com/starfishlabs/oasis-evm-web3-gateway/issues/30)
- make logging configurable
- unify logging to use the oasis logger in all modules