### PR TITLE
eth_getTransactionReceipt: return null instead of empty address

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -668,20 +668,26 @@ func (api *PublicAPI) GetTransactionReceipt(txHash common.Hash) (map[string]inte
 		"blockHash":         txRef.BlockHash,
 		"blockNumber":       hexutil.Uint64(txRef.Round),
 		"transactionIndex":  hexutil.Uint64(txRef.Index),
-		"from":              ethTx.FromAddr,
-		"to":                ethTx.ToAddr,
+		"from":              nil,
+		"to":                nil,
+	}
+	if ethTx.FromAddr != "" {
+		receipt["from"] = ethTx.FromAddr
+	}
+	if ethTx.ToAddr != "" {
+		receipt["to"] = ethTx.ToAddr
 	}
 	if logs == nil {
 		receipt["logs"] = [][]*ethtypes.Log{}
 	}
-	if len(ethTx.ToAddr) == 0 && txResults[txRef.Index].Result.IsSuccess() {
+	if ethTx.ToAddr == "" && txResults[txRef.Index].Result.IsSuccess() {
 		var out []byte
 		if err := cbor.Unmarshal(txResults[txRef.Index].Result.Ok, &out); err != nil {
 			return nil, err
 		}
 		receipt["contractAddress"] = common.BytesToAddress(out)
 	}
-	api.Logger.Debug("eth_getTransactionReceipt end")
+	api.Logger.Debug("eth_getTransactionReceipt done", "receipt", receipt)
 	return receipt, nil
 }
 


### PR DESCRIPTION
This makes the transaction receipt response compatible with `ropsten` (and other networks?), where in contract creation transactions the `to` field should is  set to `null` instead of an empty string.
![image](https://user-images.githubusercontent.com/3691472/141262888-f23d87aa-0720-47b9-a8c8-83eed5bedd83.png)
