### PR TITLE
rpc/eth: return correct block hashes

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -105,7 +105,8 @@ func (api *PublicAPI) roundParamFromBlockNum(blockNum ethrpc.BlockNumber) (uint6
 }
 
 func (api *PublicAPI) getRPCBlockData(oasisBlock *block.Block) (uint64, ethtypes.Transactions, uint64, []*ethtypes.Log, error) {
-	bhash, _ := oasisBlock.Header.IORoot.MarshalBinary()
+	encoded := oasisBlock.Header.EncodedHash()
+	bHash, _ := encoded.MarshalBinary()
 	blockNum := oasisBlock.Header.Round
 	ethTxs := ethtypes.Transactions{}
 	var gasUsed uint64
@@ -149,8 +150,9 @@ func (api *PublicAPI) getRPCBlockData(oasisBlock *block.Block) (uint64, ethtypes
 			}
 		}
 
-		logs = logs2EthLogs(oasisLogs, oasisBlock.Header.Round, common.BytesToHash(bhash), ethTx.Hash(), uint32(txIndex))
+		logs = logs2EthLogs(oasisLogs, oasisBlock.Header.Round, common.BytesToHash(bHash), ethTx.Hash(), uint32(txIndex))
 	}
+
 	return blockNum, ethTxs, gasUsed, logs, nil
 }
 

--- a/rpc/utils/utils.go
+++ b/rpc/utils/utils.go
@@ -7,9 +7,9 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
-
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+
+	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
 )
 
 var (
@@ -26,11 +26,11 @@ func ConvertToEthBlock(
 	logs []*ethtypes.Log,
 	gas uint64,
 ) (map[string]interface{}, error) {
-	// TODO tx releated
-	bhash, _ := block.Header.IORoot.MarshalBinary()
-	bprehash, _ := block.Header.PreviousHash.MarshalBinary()
-	bshash, _ := block.Header.StateRoot.MarshalBinary()
-	// btxhash, _ := block.Header.MessagesHash.MarshalBinary()
+	encoded := block.Header.EncodedHash()
+	bHash, _ := encoded.MarshalBinary()
+	bPrevHash, _ := block.Header.PreviousHash.MarshalBinary()
+	bStateHash, _ := block.Header.StateRoot.MarshalBinary()
+
 	bloom := ethtypes.BytesToBloom(ethtypes.LogsBloom(logs))
 	gasUsed := big.NewInt(0).SetUint64(gas)
 
@@ -43,12 +43,12 @@ func ConvertToEthBlock(
 
 	res := map[string]interface{}{
 		"number":           hexutil.Uint64(block.Header.Round),
-		"hash":             hexutil.Bytes(bhash),
-		"parentHash":       common.BytesToHash(bprehash),
+		"hash":             common.BytesToHash(bHash),
+		"parentHash":       common.BytesToHash(bPrevHash),
 		"nonce":            ethtypes.BlockNonce{},
 		"sha3Uncles":       ethtypes.EmptyUncleHash,
 		"logsBloom":        bloom,
-		"stateRoot":        hexutil.Bytes(bshash),
+		"stateRoot":        hexutil.Bytes(bStateHash),
 		"miner":            defaultValidatorAddr,
 		"mixHash":          common.Hash{},
 		"difficulty":       (*hexutil.Big)(big.NewInt(0)),


### PR DESCRIPTION
Fixes https://github.com/starfishlabs/oasis-evm-web3-gateway/issues/56

Before in a couple of places `IORoot` header was used instead of the round header. Indexer does index the correct thing already.