### PR TITLE
transactionReceipt: return explicit null for empty contract

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -672,6 +672,7 @@ func (api *PublicAPI) GetTransactionReceipt(txHash common.Hash) (map[string]inte
 		"transactionIndex":  hexutil.Uint64(txRef.Index),
 		"from":              nil,
 		"to":                nil,
+		"contractAddress":   nil,
 	}
 	if ethTx.FromAddr != "" {
 		receipt["from"] = ethTx.FromAddr


### PR DESCRIPTION
Similar to: https://github.com/starfishlabs/oasis-evm-web3-gateway/pull/53

apparently some tools (e.g. this specific blockexplorer that im testing with) expect explicit `null` instead of just the field not being present. 