### PR TITLE
utils/NewRPCTransaction: fix double encoded input

### DIFF
--- a/rpc/utils/utils.go
+++ b/rpc/utils/utils.go
@@ -97,7 +97,7 @@ func NewRPCTransaction(
 		GasFeeCap: (*hexutil.Big)(gasFee),
 		GasTipCap: (*hexutil.Big)(gasTip),
 		Hash:      common.HexToHash(dbTx.Hash),
-		Input:     hexutil.Bytes(dbTx.Data),
+		Input:     common.Hex2Bytes(dbTx.Data),
 		Nonce:     hexutil.Uint64(dbTx.Nonce),
 		To:        &to,
 		Value:     (*hexutil.Big)(value),


### PR DESCRIPTION
This resulted in the `input` field being hex-encoded two times in `getTransaction*` method responses.
 
Did also check the rest of the code, seems like this is the only case where a string was invalidly converted into `hexutil.Bytes`.