### PR TITLE
getEvents: fix for queries without provided block hash

### DIFF
--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -68,7 +68,7 @@ type GetEthInfoBackend interface {
 	GetTransactionByBlockHashAndIndex(blockHash ethcommon.Hash, txIndex int) (*model.Transaction, error)
 	GetTransactionReceipt(txHash ethcommon.Hash) (map[string]interface{}, error)
 	BlockNumber() (uint64, error)
-	GetLogs(blockHash ethcommon.Hash, startRound, endRound uint64) ([]*model.Log, error)
+	GetLogs(startRound, endRound uint64) ([]*model.Log, error)
 }
 
 // Backend is the indexer backend interface.
@@ -370,8 +370,8 @@ func (p *psqlBackend) BlockNumber() (uint64, error) {
 }
 
 // GetLogs returns logs from db.
-func (p *psqlBackend) GetLogs(blockHash ethcommon.Hash, startRound, endRound uint64) ([]*model.Log, error) {
-	return p.storage.GetLogs(blockHash.String(), startRound, endRound)
+func (p *psqlBackend) GetLogs(startRound, endRound uint64) ([]*model.Log, error) {
+	return p.storage.GetLogs(startRound, endRound)
 }
 
 // Close closes postgresql backend.

--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -549,9 +549,9 @@ func (api *PublicAPI) GetLogs(filter filters.FilterCriteria) ([]*ethtypes.Log, e
 	// TODO: filter addresses and topics
 
 	ethLogs := []*ethtypes.Log{}
-	dbLogs, err := api.backend.GetLogs(*filter.BlockHash, startRoundInclusive, endRoundInclusive)
+	dbLogs, err := api.backend.GetLogs(startRoundInclusive, endRoundInclusive)
 	if err != nil {
-		return ethLogs, nil
+		return ethLogs, ErrInternalQuery
 	}
 	ethLogs = utils.DB2EthLogs(dbLogs)
 

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -263,10 +263,10 @@ func (db *PostDB) GetTransactionReceipt(txHash string) (*model.Receipt, error) {
 }
 
 // GetLogs return the logs by block hash and round.
-func (db *PostDB) GetLogs(blockHash string, startRound, endRound uint64) ([]*model.Log, error) {
+func (db *PostDB) GetLogs(startRound, endRound uint64) ([]*model.Log, error) {
 	logs := []*model.Log{}
 	err := db.DB.Model(&logs).
-		Where("block_hash=? AND (round BETWEEN ? AND ?)", blockHash, startRound, endRound).Select()
+		Where("(round BETWEEN ? AND ?)", startRound, endRound).Select()
 	if err != nil {
 		return nil, err
 	}

--- a/storage/types.go
+++ b/storage/types.go
@@ -56,5 +56,5 @@ type Storage interface {
 	// GetTransactionReceipt returns the receipt of the transaction.
 	GetTransactionReceipt(txHash string) (*model.Receipt, error)
 
-	GetLogs(blockHash string, startRound, endRound uint64) ([]*model.Log, error)
+	GetLogs(startRound, endRound uint64) ([]*model.Log, error)
 }

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -302,4 +303,13 @@ func TestEth_GetTransactionReceiptRawResponses(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rawRsp.Result, &rsp))
 
 	require.Nil(t, rsp["contractAddress"], "contract address should be nil")
+}
+
+func TestEth_GetLogsWithoutBlockhash(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
+	defer cancel()
+
+	ec := localClient()
+	_, err := ec.FilterLogs(ctx, ethereum.FilterQuery{FromBlock: big.NewInt(1), ToBlock: big.NewInt(10)})
+	require.NoError(t, err, "getLogs without explicit block hash")
 }


### PR DESCRIPTION
Fixes: https://github.com/starfishlabs/oasis-evm-web3-gateway/issues/87

Blockhash is already used (if present) to derive the `startRound` & `endRound` no need to pass it further down to the DB queries.  