### PR TITLE
indexer: fix txreceipt logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	google.golang.org/grpc v1.41.0
 )

--- a/model/db.go
+++ b/model/db.go
@@ -101,7 +101,7 @@ type Receipt struct {
 	Status            uint   `pg:",use_zero"`
 	CumulativeGasUsed uint64 `pg:",use_zero"`
 	LogsBloom         string
-	Logs              []*Log
+	Logs              []*Log `pg:"rel:has-many,join_fk:tx_hash"`
 	TransactionHash   string `pg:",pk"`
 	BlockHash         string
 	GasUsed           uint64 `pg:",use_zero"`

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -261,7 +261,7 @@ func (db *PostDB) GetBlockTransaction(blockHash string, txIndex int) (*model.Tra
 // GetTransactionReceipt returns receipt by transaction hash.
 func (db *PostDB) GetTransactionReceipt(txHash string) (*model.Receipt, error) {
 	receipt := new(model.Receipt)
-	if err := db.DB.Model(receipt).Where("transaction_hash=?", txHash).Select(); err != nil {
+	if err := db.DB.Model(receipt).Where("transaction_hash=?", txHash).Relation("Logs").Select(); err != nil {
 		return nil, err
 	}
 

--- a/tests/keys.go
+++ b/tests/keys.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha512"
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature/secp256k1"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+	"golang.org/x/crypto/sha3"
+)
+
+// TestKey is a key used for testing.
+type TestKey struct {
+	Private      *ecdsa.PrivateKey
+	EthAddress   common.Address
+	OasisAddress types.Address
+}
+
+func newSecp256k1TestKey(seed string) TestKey {
+	pk := sha512.Sum512_256([]byte(seed))
+	ethPk, _ := crypto.HexToECDSA(hex.EncodeToString(pk[:]))
+
+	// Oasis address.
+	signer := secp256k1.NewSigner(pk[:])
+	sigspec := types.NewSignatureAddressSpecSecp256k1Eth(signer.Public().(secp256k1.PublicKey))
+
+	// Eth address.
+	h := sha3.NewLegacyKeccak256()
+	untaggedPk, _ := sigspec.Secp256k1Eth.MarshalBinaryUncompressedUntagged()
+	h.Write(untaggedPk)
+	var ethAddress [20]byte
+	copy(ethAddress[:], h.Sum(nil)[32-20:])
+
+	return TestKey{
+		Private:      ethPk,
+		OasisAddress: types.NewAddress(sigspec),
+		EthAddress:   ethAddress,
+	}
+}
+
+var (
+	TestKey1 = newSecp256k1TestKey("oasis-evm-web3-gateway/test-keys: 1")
+	TestKey2 = newSecp256k1TestKey("oasis-evm-web3-gateway/test-keys: 2")
+	TestKey3 = newSecp256k1TestKey("oasis-evm-web3-gateway/test-keys: 3")
+)

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -1,0 +1,15 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPrintTestAddresses(t *testing.T) {
+	fmt.Println("Test Key 1:")
+	fmt.Printf("Eth: %v Oasis: %v\n", TestKey1.EthAddress, TestKey1.OasisAddress)
+	fmt.Println("Test Key 2:")
+	fmt.Printf("Eth: %v Oasis: %v\n", TestKey2.EthAddress, TestKey2.OasisAddress)
+	fmt.Println("Test Key 3:")
+	fmt.Printf("Eth: %v Oasis: %v\n", TestKey3.EthAddress, TestKey3.OasisAddress)
+}

--- a/tests/rpc/tx_test.go
+++ b/tests/rpc/tx_test.go
@@ -14,8 +14,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	oasisTesting "github.com/oasisprotocol/oasis-sdk/client-sdk/go/testing"
 	"github.com/stretchr/testify/require"
+
+	"github.com/starfishlabs/oasis-evm-web3-gateway/tests"
 )
 
 const ethTimeout = 15 * time.Second
@@ -77,7 +78,7 @@ func testContractCreation(t *testing.T, value *big.Int) uint64 {
 	chainID, err := ec.ChainID(context.Background())
 	require.Nil(t, err, "get chainid")
 
-	nonce, err := ec.NonceAt(context.Background(), oasisTesting.Dave.EthAddress, nil)
+	nonce, err := ec.NonceAt(context.Background(), tests.TestKey1.EthAddress, nil)
 	require.Nil(t, err, "get nonce failed")
 
 	// Create transaction
@@ -89,7 +90,7 @@ func testContractCreation(t *testing.T, value *big.Int) uint64 {
 		Data:     code,
 	})
 	signer := types.LatestSignerForChainID(chainID)
-	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), daveKey)
+	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
 
 	signedTx, err := tx.WithSignature(signer, signature)
@@ -126,12 +127,12 @@ func TestEth_EstimateGas(t *testing.T) {
 	chainID, err := ec.ChainID(context.Background())
 	require.Nil(t, err, "get chainid")
 
-	nonce, err := ec.NonceAt(context.Background(), oasisTesting.Dave.EthAddress, nil)
+	nonce, err := ec.NonceAt(context.Background(), tests.TestKey1.EthAddress, nil)
 	require.Nil(t, err, "get nonce failed")
 
 	// Build call args for estimate gas
 	msg := ethereum.CallMsg{
-		From:  oasisTesting.Dave.EthAddress,
+		From:  tests.TestKey1.EthAddress,
 		Value: big.NewInt(0),
 		Data:  code,
 	}
@@ -142,7 +143,7 @@ func TestEth_EstimateGas(t *testing.T) {
 	// Create transaction
 	tx := types.NewContractCreation(nonce, big.NewInt(0), gas, big.NewInt(2), code)
 	signer := types.LatestSignerForChainID(chainID)
-	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), daveKey)
+	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
 
 	signedTx, err := tx.WithSignature(signer, signature)
@@ -166,14 +167,14 @@ func TestEth_GetCode(t *testing.T) {
 	chainID, err := ec.ChainID(context.Background())
 	require.Nil(t, err, "get chainid")
 
-	nonce, err := ec.NonceAt(context.Background(), oasisTesting.Dave.EthAddress, nil)
+	nonce, err := ec.NonceAt(context.Background(), tests.TestKey1.EthAddress, nil)
 	require.Nil(t, err, "get nonce failed")
 	t.Logf("got nonce: %v", nonce)
 
 	// Create transaction
 	tx := types.NewContractCreation(nonce, big.NewInt(0), 500000, big.NewInt(2), code)
 	signer := types.LatestSignerForChainID(chainID)
-	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), daveKey)
+	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
 
 	signedTx, err := tx.WithSignature(signer, signature)
@@ -229,14 +230,14 @@ func TestEth_Call(t *testing.T) {
 	chainID, err := ec.ChainID(context.Background())
 	require.Nil(t, err, "get chainid")
 
-	nonce, err := ec.NonceAt(context.Background(), oasisTesting.Dave.EthAddress, nil)
+	nonce, err := ec.NonceAt(context.Background(), tests.TestKey1.EthAddress, nil)
 	require.Nil(t, err, "get nonce failed")
 	t.Logf("got nonce: %v", nonce)
 
 	// Create transaction
 	tx := types.NewContractCreation(nonce, big.NewInt(0), 500000, big.NewInt(2), code)
 	signer := types.LatestSignerForChainID(chainID)
-	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), daveKey)
+	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
 
 	signedTx, err := tx.WithSignature(signer, signature)
@@ -292,13 +293,13 @@ func TestERC20(t *testing.T) {
 	chainID, err := ec.ChainID(context.Background())
 	require.Nil(t, err, "get chainid")
 
-	nonce, err := ec.NonceAt(context.Background(), oasisTesting.Dave.EthAddress, nil)
+	nonce, err := ec.NonceAt(context.Background(), tests.TestKey1.EthAddress, nil)
 	require.Nil(t, err, "get nonce failed")
 
 	// Deploy ERC20 contract
 	tx := types.NewContractCreation(nonce, big.NewInt(0), 1000000, big.NewInt(2), code)
 	signer := types.LatestSignerForChainID(chainID)
-	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), daveKey)
+	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
 
 	signedTx, err := tx.WithSignature(signer, signature)
@@ -317,7 +318,7 @@ func TestERC20(t *testing.T) {
 	t.Logf("ERC20 address: %s", tokenAddr.Hex())
 
 	// Make transfer token transaction
-	nonce, err = ec.NonceAt(context.Background(), oasisTesting.Dave.EthAddress, nil)
+	nonce, err = ec.NonceAt(context.Background(), tests.TestKey1.EthAddress, nil)
 	require.Nil(t, err, "get nonce failed")
 	transferCall, err := testabi.Pack("transfer", common.Address{1}, big.NewInt(10))
 	if err != nil {
@@ -326,7 +327,7 @@ func TestERC20(t *testing.T) {
 
 	tx = types.NewTransaction(nonce, tokenAddr, big.NewInt(0), 1000000, big.NewInt(2), transferCall)
 	signer = types.LatestSignerForChainID(chainID)
-	signature, err = crypto.Sign(signer.Hash(tx).Bytes(), daveKey)
+	signature, err = crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
 	signedTx, err = tx.WithSignature(signer, signature)
 	require.Nil(t, err, "pack tx")

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -91,7 +91,14 @@ func Setup() error {
 		return fmt.Errorf("failed connecting to oasis-node: %w", err)
 	}
 
-	if err = InitialDeposit(rc, 1000000000000); err != nil {
+	// Fund test accounts.
+	if err = InitialDeposit(rc, 1000000000000, tests.TestKey1.OasisAddress); err != nil {
+		return fmt.Errorf("initial deposit failed: %w", err)
+	}
+	if err = InitialDeposit(rc, 1000000000000, tests.TestKey2.OasisAddress); err != nil {
+		return fmt.Errorf("initial deposit failed: %w", err)
+	}
+	if err = InitialDeposit(rc, 1000000000000, tests.TestKey3.OasisAddress); err != nil {
 		return fmt.Errorf("initial deposit failed: %w", err)
 	}
 
@@ -160,7 +167,7 @@ func waitForDepositEvent(ch <-chan *client.BlockEvents, from types.Address, nonc
 	}
 }
 
-func InitialDeposit(rc client.RuntimeClient, amount uint64) error {
+func InitialDeposit(rc client.RuntimeClient, amount uint64, to types.Address) error {
 	if amount == 0 {
 		return fmt.Errorf("no deposit amount provided")
 	}
@@ -169,8 +176,6 @@ func InitialDeposit(rc client.RuntimeClient, amount uint64) error {
 	}
 
 	signer := oasisTesting.Alice.Signer
-	// Corresponds to Dave's address 0x90adE3B7065fa715c7a150313877dF1d33e777D5.
-	to := oasisTesting.Dave.Address
 	extraGas := uint64(0)
 	flag.Parse()
 
@@ -225,11 +230,11 @@ func InitialDeposit(rc client.RuntimeClient, amount uint64) error {
 		return err
 	}
 
-	if err = waitForDepositEvent(acCh, oasisTesting.Alice.Address, nonce, oasisTesting.Dave.Address, ba); err != nil {
+	if err = waitForDepositEvent(acCh, oasisTesting.Alice.Address, nonce, to, ba); err != nil {
 		return fmt.Errorf("ensuring alice deposit runtime event: %w", err)
 	}
 
-	fmt.Printf("Successfully deposited %d tokens from %s to %s (eth address %x)\n", amount, oasisTesting.Alice.Address, to, oasisTesting.Dave.EthAddress)
+	fmt.Printf("Successfully deposited %d tokens from %s to %s\n", amount, oasisTesting.Alice.Address, to)
 
 	return nil
 }

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -38,5 +38,19 @@ mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 jq ".runtimes[1].version = {major:"$(emerald_ver 1)", minor:"$(emerald_ver 2)", patch:"$(emerald_ver 3)"}" "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
+# Bump the batch size (default=1).
+jq '.runtimes[1].txn_scheduler.max_batch_size=20' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
+
+jq '.runtimes[1].txn_scheduler.max_batch_size_bytes=1048576' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
+
+jq '.runtimes[1].txn_scheduler.propose_batch_timeout=2' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
+
+# Use a batch timeout of 1 second.
+jq '.runtimes[1].txn_scheduler.batch_flush_timeout=1000000000' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
+
 # Run oasis-node.
 ${OASIS_NET_RUNNER} --fixture.file "$FIXTURE_FILE" --basedir "${OASIS_NODE_DATADIR}" --basedir.no_temp_dir


### PR DESCRIPTION
Before, the transaction receipt wrongly contained the logs from all transactions in the block.

While fixing, noticed that the receipt-logs relation was not actually set up in db - so the Logs were actually duplicated once stored in the Logs table, and then also in the receipt table in a `jsonb` field.  

The model changes are breaking so either a migration or a full reinxeding is needed.

- [x] add a test