### PR TITLE
QueryLastIndexedRound: don't ignore error

### DIFF
--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -50,7 +50,7 @@ type QueryableBackend interface {
 	QueryTransactionRef(ethTxHash string) (*model.TransactionRef, error)
 
 	// QueryLastIndexedRound query continues indexed block round.
-	QueryLastIndexedRound() uint64
+	QueryLastIndexedRound() (uint64, error)
 
 	// QueryLastRetainedRound query the minimum round not pruned.
 	QueryLastRetainedRound() (uint64, error)
@@ -218,16 +218,16 @@ func (p *psqlBackend) storeIndexedRound(round uint64) error {
 }
 
 // QueryLastIndexedRound returns the last indexed round.
-func (p *psqlBackend) QueryLastIndexedRound() uint64 {
+func (p *psqlBackend) QueryLastIndexedRound() (uint64, error) {
 	p.indexedRoundMutex.Lock()
 	indexedRound, err := p.storage.GetContinuesIndexedRound()
 	if err != nil {
 		p.indexedRoundMutex.Unlock()
-		return 0
+		return 0, err
 	}
 	p.indexedRoundMutex.Unlock()
 
-	return indexedRound
+	return indexedRound, nil
 }
 
 // storeLastRetainedRound stores the last retained round.

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -78,7 +78,13 @@ func (s *Service) pruningWorker() {
 		case <-s.ctx.Done():
 			return
 		case <-time.After(pruningCheckInterval):
-			lastIndexed := s.backend.QueryLastIndexedRound()
+			lastIndexed, err := s.backend.QueryLastIndexedRound()
+			if err != nil {
+				s.Logger.Error("failed to query last indexed round",
+					"err", err,
+				)
+				continue
+			}
 
 			if lastIndexed > s.pruningStep {
 				round := lastIndexed - s.pruningStep
@@ -112,7 +118,13 @@ func (s *Service) indexingWorker() {
 			continue
 		}
 
-		lastIndexed := s.backend.QueryLastIndexedRound()
+		lastIndexed, err := s.backend.QueryLastIndexedRound()
+		if err != nil {
+			s.Logger.Error("failed to query last indexed round",
+				"err", err,
+			)
+			continue
+		}
 		if latest < lastIndexed {
 			panic("This is a new chain, please clear the db first!")
 		}

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -161,6 +161,9 @@ func (db *PostDB) GetContinuesIndexedRound() (uint64, error) {
 		Where("tip=?", model.Continues).
 		Select()
 	if err != nil {
+		if errors.Is(err, pg.ErrNoRows) {
+			return 0, nil
+		}
 		return 0, err
 	}
 
@@ -174,6 +177,9 @@ func (db *PostDB) GetLastRetainedRound() (uint64, error) {
 		Where("tip=?", model.LastRetained).
 		Select()
 	if err != nil {
+		if errors.Is(err, pg.ErrNoRows) {
+			return 0, nil
+		}
 		return 0, err
 	}
 


### PR DESCRIPTION
Before the error was silently ignored and a `0` was returned as the last indeed round, which would then trigger reindexing of the whole DB if the query failed for whatever reason.