### PR TITLE
add mock txpool_pending method

### DIFF
--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -11,6 +11,7 @@ import (
 	"github.com/starfishlabs/oasis-evm-web3-gateway/indexer"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/rpc/eth"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/rpc/net"
+	"github.com/starfishlabs/oasis-evm-web3-gateway/rpc/txpool"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/rpc/web3"
 )
 
@@ -40,6 +41,12 @@ func GetRPCAPIs(
 			Namespace: "eth",
 			Version:   "1.0",
 			Service:   eth.NewPublicAPI(ctx, client, logging.GetLogger("eth_rpc"), config.ChainID, backend),
+			Public:    true,
+		},
+		ethRpc.API{
+			Namespace: "txpool",
+			Version:   "1.0",
+			Service:   txpool.NewPublicAPI(),
 			Public:    true,
 		},
 	)

--- a/rpc/txpool/api.go
+++ b/rpc/txpool/api.go
@@ -1,0 +1,16 @@
+package txpool
+
+// PublicAPI is the txpool_ prefixed set of APIs in the Web3 JSON-RPC spec.
+type PublicAPI struct{}
+
+// NewPublicAPI creates an instance of the Web3 API.
+func NewPublicAPI() *PublicAPI {
+	return &PublicAPI{}
+}
+
+// Content returns the (always empty) contents of the txpool.
+func (api *PublicAPI) Content() (map[string][]interface{}, error) {
+	m := make(map[string][]interface{})
+	m["pending"] = []interface{}{}
+	return m, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -178,7 +178,7 @@ func (srv *Web3Gateway) startRPC() error {
 	// Configure HTTP.
 	if srv.config.HTTP != nil {
 		config := httpConfig{
-			Modules:            []string{"net", "web3", "eth"},
+			Modules:            []string{"net", "web3", "eth", "txpool"},
 			CorsAllowedOrigins: srv.config.HTTP.Cors,
 			Vhosts:             srv.config.HTTP.VirtualHosts,
 			prefix:             srv.config.HTTP.PathPrefix,
@@ -194,7 +194,7 @@ func (srv *Web3Gateway) startRPC() error {
 	// Configure WebSocket.
 	if srv.config.WS != nil {
 		config := wsConfig{
-			Modules: []string{"net", "web3", "eth"},
+			Modules: []string{"net", "web3", "eth", "txpool"},
 			Origins: srv.config.WS.Origins,
 			prefix:  srv.config.WS.PathPrefix,
 		}


### PR DESCRIPTION
Adds a mock implementation of the geth [txpool](https://geth.ethereum.org/docs/rpc/ns-txpool) `txpool_pending` method, useful if some tooling relies on the endpoint to be present