### PR TITLE
indexer: insert round records in a transaction

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -199,12 +199,13 @@ func New(
 	enablePruning bool,
 	pruningStep uint64,
 ) (*Service, Backend, error) {
-	backend, err := backendFactory(runtimeID, storage)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	backend, err := backendFactory(ctx, runtimeID, storage)
 	if err != nil {
+		cancelCtx()
 		return nil, nil, err
 	}
-
-	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	s := &Service{
 		BaseBackgroundService: *service.NewBaseBackgroundService("gateway/indexer"),

--- a/storage/types.go
+++ b/storage/types.go
@@ -1,15 +1,14 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
 )
 
 type Storage interface {
-	// Store stores data.
-	Store(value interface{}) error
-
-	// Update updates record.
-	Update(value interface{}) error
+	// Upsert upserts a record.
+	Upsert(value interface{}) error
 
 	// Delete deletes all records with round less than the given round.
 	Delete(table interface{}, round uint64) error
@@ -56,5 +55,11 @@ type Storage interface {
 	// GetTransactionReceipt returns the receipt of the transaction.
 	GetTransactionReceipt(txHash string) (*model.Receipt, error)
 
+	// GetLogs returns all logs between start and end rounds.
 	GetLogs(startRound, endRound uint64) ([]*model.Log, error)
+
+	// RunInTransaction runs a function in a transaction. If function
+	// returns an error transaction is rolled back, otherwise transaction
+	// is committed.
+	RunInTransaction(ctx context.Context, fn func(Storage) error) error
 }

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -14,6 +14,7 @@ import (
 
 	cmnEth "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/go-pg/pg/v10"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
@@ -241,7 +242,7 @@ func InitialDeposit(rc client.RuntimeClient, amount uint64, to types.Address) er
 
 // Shutdown stops web3 gateway.
 func Shutdown() error {
-	if err := model.TruncateModel(db.DB); err != nil {
+	if err := model.TruncateModel(db.DB.(*pg.DB)); err != nil {
 		return fmt.Errorf("db cleanup failed: %w", err)
 	}
 


### PR DESCRIPTION
Adds support for transactions and indexes a round in a transaction.  Before, the round state was inconsistent while the round was being indexed.

Also replaces `Store` and `Update` with a single `Upsert` method, as previously both methods called `upsert` internally.