### PR TITLE
indexer: fix indexing round 0

### DIFF
--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -217,7 +217,7 @@ func (p *psqlBackend) storeIndexedRound(round uint64) error {
 
 // QueryLastIndexedRound returns the last indexed round.
 func (p *psqlBackend) QueryLastIndexedRound() (uint64, error) {
-	indexedRound, err := p.storage.GetContinuesIndexedRound()
+	indexedRound, err := p.storage.GetLastIndexedRound()
 	if err != nil {
 		return 0, err
 	}

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -150,15 +150,15 @@ func (db *PostDB) GetLatestBlockHash() (string, error) {
 	return blk.Hash, nil
 }
 
-// GetContinuesIndexedRound returns latest continues indexed block round.
-func (db *PostDB) GetContinuesIndexedRound() (uint64, error) {
+// GetLastIndexedRound returns latest indexed block round.
+func (db *PostDB) GetLastIndexedRound() (uint64, error) {
 	indexedRound := new(model.IndexedRoundWithTip)
 	err := db.DB.Model(indexedRound).
 		Where("tip=?", model.Continues).
 		Select()
 	if err != nil {
 		if errors.Is(err, pg.ErrNoRows) {
-			return 0, nil
+			return 0, storage.ErrNoRoundsIndexed
 		}
 		return 0, err
 	}

--- a/storage/psql/psql_test.go
+++ b/storage/psql/psql_test.go
@@ -175,8 +175,8 @@ func TestUpsert(t *testing.T) {
 	}
 	require.NoError(db.Upsert(ir1), "update")
 
-	r1, err := db.GetContinuesIndexedRound()
-	require.NoError(err, "GetContinuesIndexedRound")
+	r1, err := db.GetLastIndexedRound()
+	require.NoError(err, "GetLastIndexedRound")
 	require.EqualValues(1, r1)
 
 	ir2 := &model.IndexedRoundWithTip{
@@ -184,8 +184,8 @@ func TestUpsert(t *testing.T) {
 		Round: 2,
 	}
 	require.NoError(db.Upsert(ir2), "update")
-	r2, err := db.GetContinuesIndexedRound()
-	require.NoError(err, "GetContinuesIndexedRound")
+	r2, err := db.GetLastIndexedRound()
+	require.NoError(err, "GetLastIndexedRound")
 	require.EqualValues(2, r2)
 
 	ir3 := &model.IndexedRoundWithTip{
@@ -193,8 +193,8 @@ func TestUpsert(t *testing.T) {
 		Round: 3,
 	}
 	require.NoError(db.Upsert(ir3), "update")
-	r3, err := db.GetContinuesIndexedRound()
-	require.NoError(err, "GetContinuesIndexedRound")
+	r3, err := db.GetLastIndexedRound()
+	require.NoError(err, "GetLastIndexedRound")
 	require.EqualValues(3, r3)
 }
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -2,9 +2,14 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
 )
+
+// ErrNoRoundsIndexed is the error returned by last indexed round when no rounds
+// are indexed.
+var ErrNoRoundsIndexed = fmt.Errorf("no rounds indexed")
 
 type Storage interface {
 	// Upsert upserts a record.
@@ -25,8 +30,8 @@ type Storage interface {
 	// GetTransactionRef returns block hash, round and index of the transaction.
 	GetTransactionRef(ethTxHash string) (*model.TransactionRef, error)
 
-	// GetContinuesIndexedRound query continues indexed block round.
-	GetContinuesIndexedRound() (uint64, error)
+	// GetLastIndexedRound query the last indexed round.
+	GetLastIndexedRound() (uint64, error)
 
 	// GetLastRetainedRound query the minimum round not pruned.
 	GetLastRetainedRound() (uint64, error)

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -205,6 +205,17 @@ func TestEth_GetBlockByNumberLatest(t *testing.T) {
 	require.Greater(t, block.NumberU64(), uint64(0))
 }
 
+func TestEth_GetBlockByNumberEarliest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
+	defer cancel()
+	ec := localClient()
+
+	// Explicitly query latest block number.
+	block, err := ec.BlockByNumber(ctx, big.NewInt(0))
+	require.NoError(t, err, "get latest block number")
+	require.Equal(t, block.NumberU64(), uint64(0))
+}
+
 func TestEth_GetBlockTransactionCountByNumberLatest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()


### PR DESCRIPTION
Before, indexing always started at `QueryLastIndexedRound() + 1` (adjusted by node pruning).

This was incorrect for the case when no rounds are indexed, as in that case the `QueryLastIndexedRound()` returned `0` and indexing started at round `1`

This also caused `earliest` block queries to fail (when the earliest round was 0 and there was no pruning), as it tried to query round `0` which was not indexed.