### PR TITLE
rpc/eth/api: logging consistency

### DIFF
--- a/rpc/utils/utils.go
+++ b/rpc/utils/utils.go
@@ -13,7 +13,7 @@ import (
 )
 
 // NewRPCTransaction returns a transaction that will serialize to the RPC representation.
-func NewRPCTransaction(dbTx *model.Transaction) (*RPCTransaction, error) {
+func NewRPCTransaction(dbTx *model.Transaction) *RPCTransaction {
 	gasPrice, _ := new(big.Int).SetString(dbTx.GasPrice, 10)
 	gasFee, _ := new(big.Int).SetString(dbTx.GasFeeCap, 10)
 	gasTip, _ := new(big.Int).SetString(dbTx.GasTipCap, 10)
@@ -67,7 +67,7 @@ func NewRPCTransaction(dbTx *model.Transaction) (*RPCTransaction, error) {
 		resTx.To = &to
 	}
 
-	return resTx, nil
+	return resTx
 }
 
 // ConvertToEthBlock converts block in db to rpc response format of a block.
@@ -76,7 +76,7 @@ func ConvertToEthBlock(block *model.Block, fullTx bool) map[string]interface{} {
 	diff, _ := v1.SetString(block.Header.Difficulty, 10)
 	transactions := []interface{}{}
 	for _, dbTx := range block.Transactions {
-		tx, _ := NewRPCTransaction(dbTx)
+		tx := NewRPCTransaction(dbTx)
 		if fullTx {
 			transactions = append(transactions, tx)
 		} else {


### PR DESCRIPTION
Makes logging more consistent.

Fixes:
- don't return internal storage errors in api responses: https://github.com/starfishlabs/oasis-evm-web3-gateway/issues/107
- leasen log error for "expected" (user triggered) errors to `debug` https://github.com/starfishlabs/oasis-evm-web3-gateway/issues/62
- don't return error if querying nonexistent block, transaction