### PR TITLE
implement /health endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func runRoot() error {
 		return err
 	}
 	w3.RegisterAPIs(rpc.GetRPCAPIs(ctx, rc, backend, cfg.Gateway))
+	w3.RegisterHealthChecks([]server.HealthCheck{indx})
 
 	svr := server.Server{
 		Config: cfg,

--- a/tests/rpc/health_test.go
+++ b/tests/rpc/health_test.go
@@ -1,0 +1,26 @@
+package rpc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCheck(t *testing.T) {
+	// Ensure the initial health-check was done.
+	<-time.After(20 * time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
+	defer cancel()
+	endpoint, err := w3.GetHTTPEndpoint()
+	require.NoError(t, err)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/health", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "health request")
+	defer resp.Body.Close()
+	require.Equal(t, resp.StatusCode, http.StatusOK, "health check response")
+}

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -126,6 +126,7 @@ func Setup() error {
 	}
 
 	w3.RegisterAPIs(rpc.GetRPCAPIs(context.Background(), rc, backend, tests.TestsConfig.Gateway))
+	w3.RegisterHealthChecks([]server.HealthCheck{indx})
 
 	if err = w3.Start(); err != nil {
 		w3.Close()


### PR DESCRIPTION
Fixes: https://github.com/starfishlabs/oasis-evm-web3-gateway/issues/86

Implements `/health` endpoint.

The health-check is:
- query db for latest indexed round
- query node for latest round
- compare rounds (ensure these are not too far apart)

Note: oasis-node status is not queried (as was mentioned in the issue) so that gateway does not need access to the `Control` endpoint of the oasis-node.