### PR TITLE
db: add support for migrations

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,12 +12,14 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	"github.com/spf13/cobra"
+	"github.com/uptrace/bun"
 	"google.golang.org/grpc"
 
 	"github.com/starfishlabs/oasis-evm-web3-gateway/conf"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/filters"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/indexer"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/log"
+	"github.com/starfishlabs/oasis-evm-web3-gateway/model"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/rpc"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/server"
 	"github.com/starfishlabs/oasis-evm-web3-gateway/storage/psql"
@@ -26,16 +28,40 @@ import (
 var (
 	// Path to the configuration file.
 	configFile string
+	// Allow unsafe operations.
+	allowUnsafe bool
+
 	// Oasis-web3-gateway root command.
 	rootCmd = &cobra.Command{
 		Use:   "oasis-evm-web3-gateway",
 		Short: "oasis-evm-web3-gateway",
 		RunE:  exec,
 	}
+
+	// Truncate DB.
+	truncateCmd = &cobra.Command{
+		Use:   "truncate-db",
+		Short: "truncate-db",
+		RunE:  truncateExec,
+	}
+
+	// Migrate DB.
+	migrateCmd = &cobra.Command{
+		Use:   "migrate-db",
+		Short: "migrate-db",
+		RunE:  migrateExec,
+	}
 )
 
 func init() {
 	rootCmd.Flags().StringVar(&configFile, "config", "./conf/server.yml", "path to the config.yml file")
+
+	truncateCmd.Flags().StringVar(&configFile, "config", "./conf/server.yml", "path to the config.yml file")
+	truncateCmd.Flags().BoolVar(&allowUnsafe, "unsafe", false, "allow destructive unsafe operations")
+	rootCmd.AddCommand(truncateCmd)
+
+	migrateCmd.Flags().StringVar(&configFile, "config", "./conf/server.yml", "path to the config.yml file")
+	rootCmd.AddCommand(migrateCmd)
 }
 
 func main() {
@@ -47,6 +73,70 @@ func exec(cmd *cobra.Command, args []string) error {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	return nil
+}
+
+func truncateExec(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	// Initialize server config
+	cfg, err := conf.InitConfig(configFile)
+	if err != nil {
+		return err
+	}
+	// Initialize logging.
+	if err = log.InitLogging(cfg); err != nil {
+		return err
+	}
+	logger := logging.GetLogger("truncate-db")
+
+	if !allowUnsafe {
+		logger.Error("unsafe commands not allowed, ensure `--unsafe` is set")
+		return fmt.Errorf("unsafe not allowed")
+	}
+
+	// Initialize db.
+	db, err := psql.InitDB(ctx, cfg.Database)
+	if err != nil {
+		logger.Error("failed to initialize db", "err", err)
+		return err
+	}
+
+	// Truncate database.
+	if err := model.DropTables(ctx, db.DB.(*bun.DB)); err != nil {
+		logger.Error("failed to truncate db", "err", err)
+		return err
+	}
+
+	logger.Info("database truncated")
+
+	return nil
+}
+
+func migrateExec(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	// Initialize server config
+	cfg, err := conf.InitConfig(configFile)
+	if err != nil {
+		return err
+	}
+	// Initialize logging.
+	if err = log.InitLogging(cfg); err != nil {
+		return err
+	}
+	logger := logging.GetLogger("migrate-db")
+
+	// Initialize db.
+	db, err := psql.InitDB(ctx, cfg.Database)
+	if err != nil {
+		logger.Error("failed to initialize db", "err", err)
+		return err
+	}
+
+	// Run migrations.
+	if err = db.RunMigrations(ctx); err != nil {
+		return fmt.Errorf("failed to migrate DB: %w", err)
+	}
+
 	return nil
 }
 
@@ -88,6 +178,10 @@ func runRoot() error {
 	if err != nil {
 		logger.Error("failed to initialize db", "err", err)
 		return err
+	}
+	// Run migrations.
+	if err = db.RunMigrations(ctx); err != nil {
+		return fmt.Errorf("failed to migrate DB: %w", err)
 	}
 
 	// Create Indexer

--- a/model/db.go
+++ b/model/db.go
@@ -1,31 +1,5 @@
 package model
 
-import (
-	"context"
-
-	"github.com/uptrace/bun"
-)
-
-var (
-	_ bun.AfterCreateTableHook = (*Transaction)(nil)
-	_ bun.AfterCreateTableHook = (*Block)(nil)
-	_ bun.AfterCreateTableHook = (*Log)(nil)
-)
-
-// BlockRef represents the relationship between block round and block hash.
-type BlockRef struct {
-	Hash  string `bun:",pk"`
-	Round uint64
-}
-
-// TransactionRef represents the relationship between ethereum tx and oasis tx.
-type TransactionRef struct {
-	EthTxHash string `bun:",pk"`
-	Index     uint32
-	Round     uint64
-	BlockHash string
-}
-
 // AccessTuple is the element of an AccessList.
 type AccessTuple struct {
 	Address     string
@@ -67,41 +41,12 @@ type Transaction struct {
 	V, R, S    string
 }
 
-func (*Transaction) AfterCreateTable(ctx context.Context, query *bun.CreateTableQuery) error {
-	_, err := query.DB().NewCreateIndex().
-		Model((*Transaction)(nil)).
-		Index("transaction_on_block_hash").
-		Column("block_hash").
-		Exec(ctx)
-	if err != nil {
-		return err
-	}
-
-	_, err = query.DB().NewCreateIndex().
-		Model((*Transaction)(nil)).
-		Index("transaction_on_round").
-		Column("round").
-		Exec(ctx)
-
-	return err
-}
-
 // Block represents ethereum block.
 type Block struct {
 	Hash         string `bun:",pk"`
 	Round        uint64
 	Header       *Header
 	Transactions []*Transaction `bun:"rel:has-many,join:hash=block_hash"`
-}
-
-func (*Block) AfterCreateTable(ctx context.Context, query *bun.CreateTableQuery) error {
-	_, err := query.DB().NewCreateIndex().
-		Model((*Block)(nil)).
-		Index("block_on_round").
-		Column("round").
-		Exec(ctx)
-
-	return err
 }
 
 // Header represents ethereum block header.
@@ -135,25 +80,6 @@ type Log struct {
 	TxIndex   uint
 	Index     uint `bun:",pk,allowzero"`
 	Removed   bool
-}
-
-func (*Log) AfterCreateTable(ctx context.Context, query *bun.CreateTableQuery) error {
-	_, err := query.DB().NewCreateIndex().
-		Model((*Log)(nil)).
-		Index("log_on_block_hash").
-		Column("block_hash").
-		Exec(ctx)
-	if err != nil {
-		return err
-	}
-
-	_, err = query.DB().NewCreateIndex().
-		Model((*Log)(nil)).
-		Index("log_on_round").
-		Column("round").
-		Exec(ctx)
-
-	return err
 }
 
 type Receipt struct {

--- a/model/init.go
+++ b/model/init.go
@@ -2,41 +2,79 @@ package model
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/migrate"
+
+	"github.com/starfishlabs/oasis-evm-web3-gateway/model/migrations"
 )
 
-var tables = []interface{}{
-	new(AccessTuple),
-	new(Block),
-	new(BlockRef),
-	new(Header),
-	new(Transaction),
-	new(TransactionRef),
-	new(IndexedRoundWithTip),
-	new(Receipt),
-	new(Log),
-}
+// DropTables deletes all database tables in the `public` schema of the configured database.
+//
+// Note: this method assumes that PostgresSQL is used as the underlying db.
+func DropTables(ctx context.Context, db *bun.DB) error {
+	logger := logging.GetLogger("migration")
 
-// CreateTables creates tables.
-func CreateTables(ctx context.Context, db *bun.DB) error {
-	for _, tb := range tables {
-		_, err := db.NewCreateTable().Model(tb).IfNotExists().Exec(ctx)
+	rows, err := db.QueryContext(ctx, "SELECT * FROM pg_tables")
+	if err != nil {
+		return err
+	}
+	if err = rows.Err(); err != nil {
+		return err
+	}
+
+	var results []map[string]interface{}
+	if err = db.ScanRows(ctx, rows, &results); err != nil {
+		return err
+	}
+
+	for _, result := range results {
+		tableName := string(result["tablename"].([]byte))
+		schemaName := string(result["schemaname"].([]byte))
+
+		// Skip internal pg tables.
+		if strings.Compare(schemaName, "public") != 0 {
+			continue
+		}
+
+		logger.Info("dropping table", "table_name", tableName)
+
+		_, err := db.ExecContext(ctx, fmt.Sprintf("DROP TABLE \"%s\" CASCADE", tableName))
 		if err != nil {
-			return err
+			logger.Error("failed dropping table", "table_name", tableName, "err", err)
+			continue
 		}
 	}
 
 	return nil
 }
 
-// TruncateModel clears any DB records.
-func TruncateModel(ctx context.Context, db *bun.DB) error {
-	for _, tb := range tables {
-		if _, err := db.NewDropTable().Model(tb).IfExists().Exec(ctx); err != nil {
-			return err
-		}
+// Migrate migrates the DB to latest version.
+func Migrate(ctx context.Context, db *bun.DB) error {
+	logger := logging.GetLogger("migration")
+
+	// Initialize the migrator.
+	migrator := migrate.NewMigrator(db, migrations.Migrations)
+	if err := migrator.Init(ctx); err != nil {
+		logger.Error("failed to init migrations", "err", err)
+		return err
 	}
+
+	// Run migrations.
+	_, err := migrator.Migrate(ctx)
+	if err != nil {
+		logger.Error("failed to migrate db", "err", err)
+		return err
+	}
+
+	status, err := migrator.MigrationsWithStatus(ctx)
+	if err != nil {
+		return err
+	}
+	logger.Info("migration done", "applied", status.Applied(), "last_group", status.LastGroupID(), "status", status.String())
 
 	return nil
 }

--- a/model/migrations/20211213143752_initial.up.sql
+++ b/model/migrations/20211213143752_initial.up.sql
@@ -1,0 +1,97 @@
+CREATE TABLE access_tuples (
+    address character varying,
+    storage_keys jsonb
+);
+
+--bun:split
+
+CREATE TABLE blocks (
+    hash character varying NOT NULL,
+    round bigint,
+    header jsonb
+);
+
+ALTER TABLE ONLY public.blocks
+    ADD CONSTRAINT blocks_pkey PRIMARY KEY (hash);
+
+CREATE UNIQUE INDEX block_on_round ON blocks USING btree (round);
+
+--bun:split
+
+CREATE TABLE logs (
+    address character varying,
+    topics jsonb,
+    data character varying,
+    round bigint,
+    block_hash character varying,
+    tx_hash character varying NOT NULL,
+    tx_index bigint,
+    index bigint NOT NULL,
+    removed boolean
+);
+
+ALTER TABLE ONLY logs
+    ADD CONSTRAINT logs_pkey PRIMARY KEY (tx_hash, index);
+
+CREATE INDEX log_on_block_hash ON public.logs USING btree (block_hash);
+CREATE INDEX log_on_round ON public.logs USING btree (round);
+
+--bun:split
+
+CREATE TABLE receipts (
+    status bigint,
+    cumulative_gas_used bigint,
+    logs_bloom character varying,
+    transaction_hash character varying NOT NULL,
+    block_hash character varying,
+    gas_used bigint,
+    type bigint,
+    round bigint,
+    transaction_index bigint,
+    from_addr character varying,
+    to_addr character varying,
+    contract_address character varying
+);
+
+ALTER TABLE ONLY receipts
+    ADD CONSTRAINT receipts_pkey PRIMARY KEY (transaction_hash);
+
+--bun:split
+
+CREATE TABLE transactions (
+    hash character varying NOT NULL,
+    type smallint,
+    status bigint,
+    chain_id character varying,
+    block_hash character varying,
+    round bigint,
+    index integer,
+    gas bigint,
+    gas_price character varying,
+    gas_tip_cap character varying,
+    gas_fee_cap character varying,
+    nonce bigint,
+    from_addr character varying,
+    to_addr character varying,
+    value character varying,
+    data character varying,
+    access_list jsonb,
+    v character varying,
+    r character varying,
+    s character varying
+);
+
+ALTER TABLE ONLY transactions
+    ADD CONSTRAINT transactions_pkey PRIMARY KEY (hash);
+
+CREATE INDEX transaction_on_block_hash ON transactions USING btree (block_hash);
+CREATE INDEX transaction_on_round ON transactions USING btree (round);
+
+--bun:split
+
+CREATE TABLE indexed_round_with_tips (
+    tip character varying NOT NULL,
+    round bigint
+);
+ALTER TABLE ONLY indexed_round_with_tips
+    ADD CONSTRAINT indexed_round_with_tips_pkey PRIMARY KEY (tip);

--- a/model/migrations/initial.go
+++ b/model/migrations/initial.go
@@ -1,0 +1,26 @@
+package migrations
+
+import (
+	"embed"
+
+	"github.com/uptrace/bun/migrate"
+)
+
+// Migrations are all migrations.
+var Migrations *migrate.Migrations
+
+//go:embed *.sql
+var migrations embed.FS
+
+func init() {
+	Migrations = migrate.NewMigrations()
+	for _, m := range []migrate.Migration{
+		// Initial.
+		{
+			Name: "20211213143752",
+			Up:   migrate.NewSQLMigrationFunc(migrations, "20211213143752_initial.up.sql"),
+		},
+	} {
+		Migrations.Add(m)
+	}
+}

--- a/storage/types.go
+++ b/storage/types.go
@@ -27,9 +27,6 @@ type Storage interface {
 	// GetLatestBlockHash returns the block hash of the latest indexed round.
 	GetLatestBlockHash(ctx context.Context) (string, error)
 
-	// GetTransactionRef returns block hash, round and index of the transaction.
-	GetTransactionRef(ctx context.Context, ethTxHash string) (*model.TransactionRef, error)
-
 	// GetLastIndexedRound query the last indexed round.
 	GetLastIndexedRound(ctx context.Context) (uint64, error)
 

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -128,6 +128,9 @@ func Setup() error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize DB: %w", err)
 	}
+	if err = db.RunMigrations(ctx); err != nil {
+		return fmt.Errorf("failed to migrate DB: %w", err)
+	}
 
 	// Create Indexer.
 	f := indexer.NewIndexBackend()
@@ -266,7 +269,7 @@ func InitialDeposit(rc client.RuntimeClient, amount uint64, to types.Address) er
 
 // Shutdown stops web3 gateway.
 func Shutdown() error {
-	if err := model.TruncateModel(context.Background(), db.DB.(*bun.DB)); err != nil {
+	if err := model.DropTables(context.Background(), db.DB.(*bun.DB)); err != nil {
 		return fmt.Errorf("db cleanup failed: %w", err)
 	}
 


### PR DESCRIPTION
- Sets up database migrations and adds the initial migration
- adds truncate database command (fixes: #97) 
- removes unneeded DB models (`BlockRefs`, `TransactionRefs`)
  - `TransactionRefs` was completely unused, `BlockRefs` contained duplicate fields already present in `Blocks`