### PR TITLE
README: code coverage badge

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -65,7 +65,7 @@ jobs:
       - run: go build
 
       - name: Unit tests with coverage
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+        run: go test -race -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -v ./...
 
       - name: Shutdown oasis-node
         run: killall oasis-node

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![ci-lint](https://github.com/oasisprotocol/oasis-evm-web3-gateway/actions/workflows/ci-lint.yml/badge.svg)](https://github.com/oasisprotocol/oasis-evm-web3-gateway/actions/workflows/ci-lint.yml)
 [![ci-test](https://github.com/oasisprotocol/oasis-evm-web3-gateway/actions/workflows/ci-test.yaml/badge.svg)](https://github.com/oasisprotocol/oasis-evm-web3-gateway/actions/workflows/ci-test.yaml)
+[![codecov](https://codecov.io/gh/oasisprotocol/oasis-evm-web3-gateway/branch/main/graph/badge.svg?token=WMx1Bg91Hm)](https://codecov.io/gh/oasisprotocol/oasis-evm-web3-gateway)
 
 
 Web3 Gateway for Oasis Emerald EVM.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - tests # Tests.


### PR DESCRIPTION
Also adds missing `-coverpkg=./...` flag otherwise the coverage analysis is done only within the package in which the tests are defined.