### PR TITLE
rpc/eth/api: fix logs filtering for multiple topics

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -599,7 +599,7 @@ func (api *PublicAPI) GetLogs(filter filters.FilterCriteria) ([]*ethtypes.Log, e
 	filtered := make([]*ethtypes.Log, 0, len(ethLogs))
 	for _, log := range ethLogs {
 		// Filter by address.
-		addressMatch := len(filtered) == 0
+		addressMatch := len(filter.Addresses) == 0
 		for _, addr := range filter.Addresses {
 			if bytes.Equal(addr[:], log.Address[:]) {
 				addressMatch = true

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -447,6 +447,13 @@ func TestEth_GetLogsMultiple(t *testing.T) {
 
 		// Check emitted logs.
 		require.Len(t, receipt.Logs, 3, "3 logs expected")
+
+		// Query logs for the block.
+		blockLogs, err := ec.FilterLogs(ctx, ethereum.FilterQuery{FromBlock: receipt.BlockNumber, ToBlock: receipt.BlockNumber})
+		require.NoError(t, err, "filter logs by block")
+		for _, log := range receipt.Logs {
+			require.Contains(t, blockLogs, *log, "all receipt logs should be present in block logs")
+		}
 	}
 
 	// Submit transactions in parallel so the transactions (likely) get processed


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-evm-web3-gateway/issues/142

Fix invalid `addressMatch` check. Before, for log filter queries that did not use the address filter, at most one log was always returned (since the invalid `addresMatch` would always early exit the loop after `len(filtered)>0`).