### PR TITLE
feat: automate releaes using goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+          distribution: goreleaser
+          version: 1.2.5
+      - name: Build and publish the next release
+        run: |
+          make release-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ emerald-web3-gateway
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .vscode
+
+dist/

--- a/.gitlint
+++ b/.gitlint
@@ -8,6 +8,9 @@ ignore=body-is-missing
 [title-max-length]
 line-length=80
 
+[title-match-regex]
+regex=^(breaks|fix|feat|other|deps)(\(\w*\))?:.*$
+
 [body-max-line-length]
 line-length=80
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,65 @@
+project_name: Emerald Web3 Gateway
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - binary: emerald-web3-gateway
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -buildid=
+      - "{{.Env.GOLDFLAGS_VERSION}}"
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+archives:
+  - name_template: "{{replace .ProjectName \" \" \"_\" | tolower}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+    wrap_in_directory: true
+
+checksum:
+  name_template: SHA256SUMS-{{.Version}}.txt
+  algorithm: sha256
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+
+  # Enable this after the initial release.
+  # groups:
+  #   - title: Breaking changes
+  #     regexp: "^.*breaks[(\\w)]*:+.*$"
+  #     order: 0
+  #   - title: New Features
+  #     regexp: "^.*feat[(\\w)]*:+.*$"
+  #     order: 5
+  #   - title: Bug fixes
+  #     regexp: "^.*fix[(\\w)]*:+.*$"
+  #     order: 10
+  #   - title: Dependencies updates
+  #     regexp: "^.*deps[(\\w)]*:+.*$"
+  #     order: 500
+  #   - title: Other changes
+  #     order: 999
+
+release:
+  name_template: "{{.ProjectName}} {{.Version}}"
+  footer: |
+    **Full Changelog**: https://github.com/oasisprotocol/emerald-web3-gateway/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+    ### Running the gateway
+
+    https://github.com/oasisprotocol/emerald-web3-gateway/blob/{{ .Tag }}/README.md#running-the-gateway-on-testnetmainnet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,12 +165,11 @@ A quick summary:
 - Separate subject from body with a blank line.
 - Limit the subject line to 80 characters.
 - Prefix the subject line with one of:
-  - "breaks: \<description\>" if commit implements a non-backward compatible
-    breaking change
-  - "fix: \<description\>" if commit implements a bugfix
-  - "feat: \<description\>" if commit implements a new description
-  - "deps: \<description>\" if commit updates a dependency
-  - "other: \<description\>" if commit doesn't fall in any of the above categories
+  - "breaks:" if commit implements a non-backward compatible breaking change
+  - "fix:" if commit implements a bugfix
+  - "feat:" if commit implements a new feature
+  - "deps:" if commit updates a dependency
+  - "other:" if commit doesn't fall in any of the above categories
 - Do not end the subject line with a period.
 - Wrap the body at 80 characters.
 - Use the body to explain _what_ and _why_ vs. _how_.

--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,19 @@ lint-go-mod-tidy:
 	@$(CHECK_GO_MOD_TIDY)
 
 lint-git:
-	@$(CHECK_GITLINT)
+	@$(CHECK_GITLINT) || \
+	($(ECHO) "See commit style guide at: https://github.com/oasisprotocol/emerald-web3-gateway/blob/main/CONTRIBUTING.md#git-commit-messages" && \
+	exit 1)
 
 lint: $(lint-targets)
+
+release-build:
+	@goreleaser release --rm-dist
 
 # List of targets that are not actual files.
 .PHONY: \
 	all build \
 	test \
 	fmt \
-	$(lint-targets) lint
+	$(lint-targets) lint \
+	release-build

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -15,6 +15,6 @@ Push the tag upstream:
 git push origin "${VERSION}"
 ```
 
-This will trigger the release action will create a release, together with the
-changelog with changes since the previous release. Commit messages are used
-to generate the changelog.
+This will trigger the release action that will create a and publish a release,
+together with the changelog with changes since the previous release. Commit
+messages are used to generate the changelog.


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/emerald-web3-gateway/issues/93

- goreleaser is used to build the binaries
- changelog is generated from commits

TODO:
- [x] add a release process document
- [ ] after the initial release, start using commit messages to group change log sections (see `changelog.groups` in goreleaser.yml)
