### PR TITLE
other: enable groups in release changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,23 +37,21 @@ changelog:
     - Merge pull request
     - Merge remote-tracking branch
     - Merge branch
-
-  # Enable this after the initial release.
-  # groups:
-  #   - title: Breaking changes
-  #     regexp: "^.*breaks[(\\w)]*:+.*$"
-  #     order: 0
-  #   - title: New Features
-  #     regexp: "^.*feat[(\\w)]*:+.*$"
-  #     order: 5
-  #   - title: Bug fixes
-  #     regexp: "^.*fix[(\\w)]*:+.*$"
-  #     order: 10
-  #   - title: Dependencies updates
-  #     regexp: "^.*deps[(\\w)]*:+.*$"
-  #     order: 500
-  #   - title: Other changes
-  #     order: 999
+  groups:
+    - title: Breaking changes
+      regexp: "^.*breaks[(\\w)]*:+.*$"
+      order: 0
+    - title: New Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 5
+    - title: Bug fixes
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 10
+    - title: Dependencies updates
+      regexp: "^.*deps[(\\w)]*:+.*$"
+      order: 500
+    - title: Other changes
+      order: 999
 
 release:
   name_template: "{{.ProjectName}} {{.Version}}"


### PR DESCRIPTION
Now that the initial release is created, and the [commit message style](https://github.com/oasisprotocol/emerald-web3-gateway/blob/main/CONTRIBUTING.md#git-commit-messages) is enforced for new commits, enable change log groups for future releases.