### PR TITLE
duplicate txs

### DIFF
--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -82,9 +82,6 @@ type Backend interface {
 	// Prune removes indexed data for rounds equal to or earlier than the passed round.
 	Prune(round uint64) error
 
-	// UpdateLastIndexedRound updates the last indexed round metadata.
-	UpdateLastIndexedRound(round uint64) error
-
 	// Close performs backend-specific cleanup. The backend should not be used anymore after calling
 	// this method.
 	Close()
@@ -175,16 +172,6 @@ func (ib *indexBackend) QueryBlockHash(round uint64) (ethcommon.Hash, error) {
 		return ethcommon.Hash{}, err
 	}
 	return ethcommon.HexToHash(blockHash), nil
-}
-
-// storeIndexedRound stores indexed round.
-func (ib *indexBackend) storeIndexedRound(round uint64) error {
-	r := &model.IndexedRoundWithTip{
-		Tip:   model.Continues,
-		Round: round,
-	}
-
-	return ib.storage.Upsert(ib.ctx, r)
 }
 
 // QueryLastIndexedRound returns the last indexed round.

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -231,14 +231,6 @@ func (s *Service) indexingWorker() {
 				)
 				break
 			}
-
-			// Update last indexed round for correct resumption.
-			if err = s.backend.UpdateLastIndexedRound(round); err != nil {
-				s.Logger.Warn("failed to update last indexed round",
-					"err", err,
-					"round", round,
-				)
-			}
 		}
 	}
 }

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -73,6 +73,26 @@ func (db *PostDB) GetTransaction(ctx context.Context, hash string) (*model.Trans
 	return tx, nil
 }
 
+// Inserts a single record in the DB.
+func (db *PostDB) Insert(ctx context.Context, value interface{}) error {
+	switch values := value.(type) {
+	case []interface{}:
+		for v := range values {
+			if _, err := db.DB.NewInsert().
+				Model(v).
+				Exec(ctx); err != nil {
+				return err
+			}
+		}
+	case interface{}:
+		_, err := db.DB.NewInsert().
+			Model(value).
+			Exec(ctx)
+		return err
+	}
+	return nil
+}
+
 func (db *PostDB) insertSingle(ctx context.Context, value interface{}, upsert bool) error {
 	typ := reflect.TypeOf(value)
 	table := db.DB.Dialect().Tables().Get(typ)

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -73,39 +73,58 @@ func (db *PostDB) GetTransaction(ctx context.Context, hash string) (*model.Trans
 	return tx, nil
 }
 
-// upsert updates record when PK conflicts, otherwise inserts.
-func (db *PostDB) upsertSingle(ctx context.Context, value interface{}) error {
+func (db *PostDB) insertSingle(ctx context.Context, value interface{}, upsert bool) error {
 	typ := reflect.TypeOf(value)
 	table := db.DB.Dialect().Tables().Get(typ)
 	pks := make([]string, len(table.PKs))
 	for i, f := range table.PKs {
 		pks[i] = f.Name
 	}
+
+	var onConflictAction string
+	switch upsert {
+	case true:
+		onConflictAction = "UPDATE"
+	case false:
+		onConflictAction = "NOTHING"
+	}
+
 	_, err := db.DB.NewInsert().
 		Model(value).
-		On(fmt.Sprintf("CONFLICT (%v) DO UPDATE", strings.Join(pks, ","))).
+		On(fmt.Sprintf("CONFLICT (%s) DO %s", strings.Join(pks, ","), onConflictAction)).
 		Exec(ctx)
 
 	return err
 }
 
-//  upsert updates record when PK conflicts, otherwise inserts.
-func (db *PostDB) upsert(ctx context.Context, value interface{}) (err error) {
+// InsertIfNotExists inserts the record if it does not yet exist.
+func (db *PostDB) InsertIfNotExists(ctx context.Context, value interface{}) error {
 	switch values := value.(type) {
 	case []interface{}:
 		for v := range values {
-			err = db.upsertSingle(ctx, v)
+			if err := db.insertSingle(ctx, v, false); err != nil {
+				return err
+			}
 		}
 	case interface{}:
-		err = db.upsertSingle(ctx, value)
+		return db.insertSingle(ctx, value, false)
 	}
-
-	return
+	return nil
 }
 
-// Store stores data in db.
+// Upsert upserts the record.
 func (db *PostDB) Upsert(ctx context.Context, value interface{}) error {
-	return db.upsert(ctx, value)
+	switch values := value.(type) {
+	case []interface{}:
+		for v := range values {
+			if err := db.insertSingle(ctx, v, true); err != nil {
+				return err
+			}
+		}
+	case interface{}:
+		return db.insertSingle(ctx, value, true)
+	}
+	return nil
 }
 
 // Delete deletes all records with round less than the given round.

--- a/storage/types.go
+++ b/storage/types.go
@@ -12,6 +12,9 @@ import (
 var ErrNoRoundsIndexed = fmt.Errorf("no rounds indexed")
 
 type Storage interface {
+	// Insert inserts a record. On conflict the insert errors.
+	Insert(ctx context.Context, value interface{}) error
+
 	// InsertIfNotExists inserts a record if a record with same primary key does not exist.
 	InsertIfNotExists(ctx context.Context, value interface{}) error
 

--- a/storage/types.go
+++ b/storage/types.go
@@ -12,6 +12,9 @@ import (
 var ErrNoRoundsIndexed = fmt.Errorf("no rounds indexed")
 
 type Storage interface {
+	// InsertIfNotExists inserts a record if a record with same primary key does not exist.
+	InsertIfNotExists(ctx context.Context, value interface{}) error
+
 	// Upsert upserts a record.
 	Upsert(ctx context.Context, value interface{}) error
 


### PR DESCRIPTION
Channges:
- does prunning in a transaction (no functional changes, should be a bit more performant vs doing all queries separately)
- fixes: https://github.com/oasisprotocol/emerald-web3-gateway/issues/152
- moves updating the last indexed round into a transaction - meaning we can change most `Upserts` to `Inserst` and error in the (unexpected) case of duplicates 

No nice way to test this case at the moment, as duplicate txs will be rejected and not executed. Would need to setup a test for the indexer on mock records.