### PR TITLE
ci: Bump emerald-paratime to 6.1.0-rc1 and oasis-core to 21.3.8

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -30,10 +30,10 @@ jobs:
         ports:
           - 5432:5432
     env:
-      OASIS_CORE_VERSION: 21.3.6
+      OASIS_CORE_VERSION: 21.3.8
       OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
-      OASIS_EMERALD_VERSION: 6.0.0-rc
+      OASIS_EMERALD_VERSION: 6.1.0-rc1
       GATEWAY__CHAIN_ID: 42261
       OASIS_EMERALD_PARATIME: ${{ github.workspace }}/oasis_core/emerald-paratime
       OASIS_NODE_DATADIR: /tmp/eth-runtime-test

--- a/indexer/utils.go
+++ b/indexer/utils.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	defaultValidatorAddr = "0x0000000000000000000000000000000088888888"
-	defaultGasLimit      = 21000 * 1000
+	defaultGasLimit      = 21_000_000
 )
 
 // Log is the Oasis Log.

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -99,7 +99,7 @@ func submitTransaction(ctx context.Context, t *testing.T, to common.Address, amo
 func submitTestTransaction(ctx context.Context, t *testing.T) *types.Receipt {
 	data := common.FromHex("0x7f7465737432000000000000000000000000000000000000000000000000000000600057")
 	to := common.BytesToAddress(common.FromHex("0x1122334455667788990011223344556677889900"))
-	return submitTransaction(ctx, t, to, big.NewInt(1), 3000003, GasPrice, data)
+	return submitTransaction(ctx, t, to, big.NewInt(1), GasLimit, GasPrice, data)
 }
 
 func TestEth_GetBalance(t *testing.T) {
@@ -423,7 +423,7 @@ func TestEth_GetLogsMultiple(t *testing.T) {
 		tx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,
 			Value:    big.NewInt(0),
-			Gas:      1_000_000,
+			Gas:      GasLimit,
 			GasPrice: GasPrice,
 			Data:     code,
 		})

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -99,7 +99,7 @@ func submitTransaction(ctx context.Context, t *testing.T, to common.Address, amo
 func submitTestTransaction(ctx context.Context, t *testing.T) *types.Receipt {
 	data := common.FromHex("0x7f7465737432000000000000000000000000000000000000000000000000000000600057")
 	to := common.BytesToAddress(common.FromHex("0x1122334455667788990011223344556677889900"))
-	return submitTransaction(ctx, t, to, big.NewInt(1), 3000003, big.NewInt(2), data)
+	return submitTransaction(ctx, t, to, big.NewInt(1), 3000003, GasPrice, data)
 }
 
 func TestEth_GetBalance(t *testing.T) {
@@ -150,8 +150,8 @@ func TestEth_SendRawTransaction(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()
 
-	receipt := submitTransaction(ctx, t, common.Address{1}, big.NewInt(1), 22000, big.NewInt(2), nil)
-	require.EqualValues(t, 0, receipt.Status)
+	receipt := submitTransaction(ctx, t, common.Address{1}, big.NewInt(1), GasLimit, GasPrice, nil)
+	require.EqualValues(t, 1, receipt.Status)
 }
 
 func TestEth_GetBlockByNumberAndGetBlockByHash(t *testing.T) {
@@ -250,7 +250,7 @@ func TestEth_GetTransactionByHash(t *testing.T) {
 	input := "0x7f7465737432000000000000000000000000000000000000000000000000000000600057"
 	data := common.FromHex(input)
 	to := common.BytesToAddress(common.FromHex("0x1122334455667788990011223344556677889900"))
-	receipt := submitTransaction(ctx, t, to, big.NewInt(1), 3000003, big.NewInt(2), data)
+	receipt := submitTransaction(ctx, t, to, big.NewInt(1), GasLimit, GasPrice, data)
 	require.EqualValues(t, 1, receipt.Status)
 	require.NotNil(t, receipt)
 
@@ -359,7 +359,7 @@ func TestEth_GetLogsWithFilters(t *testing.T) {
 		Nonce:    nonce,
 		Value:    big.NewInt(0),
 		Gas:      1000000,
-		GasPrice: big.NewInt(2),
+		GasPrice: GasPrice,
 		Data:     code,
 	})
 	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
@@ -423,8 +423,8 @@ func TestEth_GetLogsMultiple(t *testing.T) {
 		tx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,
 			Value:    big.NewInt(0),
-			Gas:      1000000,
-			GasPrice: big.NewInt(2),
+			Gas:      1_000_000,
+			GasPrice: GasPrice,
 			Data:     code,
 		})
 		signature, err := crypto.Sign(signer.Hash(tx).Bytes(), privKey)

--- a/tests/rpc/subscribe_test.go
+++ b/tests/rpc/subscribe_test.go
@@ -70,8 +70,8 @@ func TestEth_SubscribeLogs(t *testing.T) {
 		tx := types.NewTx(&types.LegacyTx{
 			Nonce:    nonce,
 			Value:    big.NewInt(0),
-			Gas:      1000000,
-			GasPrice: big.NewInt(2),
+			Gas:      1_000_000,
+			GasPrice: GasPrice,
 			Data:     code,
 		})
 		signer := types.LatestSignerForChainID(chainID)

--- a/tests/rpc/tx_test.go
+++ b/tests/rpc/tx_test.go
@@ -85,8 +85,8 @@ func testContractCreation(t *testing.T, value *big.Int) uint64 {
 	tx := types.NewTx(&types.LegacyTx{
 		Nonce:    nonce,
 		Value:    value,
-		Gas:      1000000,
-		GasPrice: big.NewInt(2),
+		Gas:      1_000_000,
+		GasPrice: GasPrice,
 		Data:     code,
 	})
 	signer := types.LatestSignerForChainID(chainID)
@@ -141,7 +141,7 @@ func TestEth_EstimateGas(t *testing.T) {
 	t.Logf("estimate gas: %v", gas)
 
 	// Create transaction
-	tx := types.NewContractCreation(nonce, big.NewInt(0), gas, big.NewInt(2), code)
+	tx := types.NewContractCreation(nonce, big.NewInt(0), gas, GasPrice, code)
 	signer := types.LatestSignerForChainID(chainID)
 	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
@@ -172,7 +172,7 @@ func TestEth_GetCode(t *testing.T) {
 	t.Logf("got nonce: %v", nonce)
 
 	// Create transaction
-	tx := types.NewContractCreation(nonce, big.NewInt(0), 500000, big.NewInt(2), code)
+	tx := types.NewContractCreation(nonce, big.NewInt(0), GasLimit, GasPrice, code)
 	signer := types.LatestSignerForChainID(chainID)
 	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
@@ -235,7 +235,7 @@ func TestEth_Call(t *testing.T) {
 	t.Logf("got nonce: %v", nonce)
 
 	// Create transaction
-	tx := types.NewContractCreation(nonce, big.NewInt(0), 500000, big.NewInt(2), code)
+	tx := types.NewContractCreation(nonce, big.NewInt(0), GasLimit, GasPrice, code)
 	signer := types.LatestSignerForChainID(chainID)
 	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
@@ -264,7 +264,6 @@ func TestEth_Call(t *testing.T) {
 		To:   &receipt.ContractAddress,
 		Data: calldata,
 	}
-
 	out, err := ec.CallContract(context.Background(), msg, nil)
 	require.NoError(t, err)
 	t.Logf("contract call return: %x", out)
@@ -297,7 +296,7 @@ func TestERC20(t *testing.T) {
 	require.Nil(t, err, "get nonce failed")
 
 	// Deploy ERC20 contract
-	tx := types.NewContractCreation(nonce, big.NewInt(0), 1000000, big.NewInt(2), code)
+	tx := types.NewContractCreation(nonce, big.NewInt(0), GasLimit, GasPrice, code)
 	signer := types.LatestSignerForChainID(chainID)
 	signature, err := crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")
@@ -325,7 +324,7 @@ func TestERC20(t *testing.T) {
 		t.Error(err)
 	}
 
-	tx = types.NewTransaction(nonce, tokenAddr, big.NewInt(0), 1000000, big.NewInt(2), transferCall)
+	tx = types.NewTransaction(nonce, tokenAddr, big.NewInt(0), GasLimit, GasPrice, transferCall)
 	signer = types.LatestSignerForChainID(chainID)
 	signature, err = crypto.Sign(signer.Hash(tx).Bytes(), tests.TestKey1.Private)
 	require.Nil(t, err, "sign tx")

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -62,12 +62,12 @@ type Response struct {
 
 const (
 	OasisBlockTimeout = 35 * time.Second
-	GasLimit          = uint64(3_000_003) // Minimum gas limit required to pass all tests without gas limit detection function.
+	GasLimit          = uint64(1_000_000) // Minimum gas limit required to pass all tests (not using gas estimation).
 )
 
 var (
 	db       *psql.PostDB
-	GasPrice = big.NewInt(10_000_000_000) // Minimum gas price as defined by in emerald: https://github.com/oasisprotocol/emerald-paratime/blob/07179c1d20eddad3b3c3c9373bc0c853ad57fa16/src/lib.rs#L36
+	GasPrice = big.NewInt(10_000_000_000) // Minimum gas price: https://github.com/oasisprotocol/emerald-paratime/blob/07179c1d20eddad3b3c3c9373bc0c853ad57fa16/src/lib.rs#L36
 	w3       *server.Web3Gateway
 )
 
@@ -240,7 +240,7 @@ func InitialDeposit(rc client.RuntimeClient, amount quantity.Quantity, to types.
 
 	// Estimate gas.
 	// Set the starting gas to something high, so we don't run out.
-	tx.AuthInfo.Fee.Gas = 1_000_000
+	tx.AuthInfo.Fee.Gas = GasLimit
 	// Estimate gas usage.
 	gas, err := core.NewV1(rc).EstimateGas(ctx, client.RoundLatest, &tx)
 	if err != nil {


### PR DESCRIPTION
This PR: 
- Bumps emerald-paratime to 6.1.0-rc1 and oasis-core to 21.3.8
- Unifies GasLimit and GasPrice in the tests
- Adds more gas checks (estimate, limit, price, remainder)