### PR TITLE
push emerald-dev image to dockerhub automatically

### DIFF
--- a/.github/workflows/docker-emerald-dev.yml
+++ b/.github/workflows/docker-emerald-dev.yml
@@ -1,0 +1,45 @@
+name: docker-emerald-dev
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # We need history to determine emerald-web3-gateway version from git tag.
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+      - name: Compute version
+        # Version emerald-dev image by date and git revision.
+        run: |
+          echo "VERSION=$(date +%Y-%m-%d-git$(git rev-parse --short HEAD))" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            VERSION=${{ env.VERSION }}
+          context: .
+          file: docker/emerald-dev/Dockerfile
+          tags: |
+            oasisprotocol/emerald-dev:latest
+            oasisprotocol/emerald-dev:latest-${{ env.VERSION }}
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ release-build:
 	@goreleaser release --rm-dist
 
 docker:
-	@docker build -t emerald-dev -f docker/emerald-dev/Dockerfile .
+	@docker build -t oasisprotocol/emerald-dev:local --build-arg VERSION=local -f docker/emerald-dev/Dockerfile .
 
 # List of targets that are not actual files.
 .PHONY: \

--- a/docker/emerald-dev/Dockerfile
+++ b/docker/emerald-dev/Dockerfile
@@ -5,11 +5,8 @@ RUN cd emerald-web3-gateway && make build
 
 FROM ubuntu:20.04
 
-ENV VERSION=22.1
 ENV OASIS_CORE_VERSION=21.3.9
 ENV EMERALD_PARATIME_VERSION=6.2.0
-
-ENV ETHEREUM_MNEMONIC="tray ripple elevator ramp insect butter top mouse old cinnamon panther chief"
 
 ENV OASIS_NODE=/oasis-node
 ENV OASIS_NET_RUNNER=/oasis-net-runner
@@ -19,6 +16,7 @@ ENV EMERALD_WEB3_GATEWAY=/emerald-web3-gateway
 ENV EMERALD_WEB3_GATEWAY_CONFIG_FILE=/emerald-dev.yml
 ENV OASIS_DEPOSIT=/oasis-deposit
 
+ARG VERSION
 ARG DEBIAN_FRONTEND=noninteractive
 
 # emerald-web3-gateway binary, config, spinup-* scripts and staking_genesis.json.
@@ -39,6 +37,9 @@ RUN tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
 RUN mkdir -p "$(dirname ${EMERALD_PARATIME})"
 ADD "https://github.com/oasisprotocol/emerald-paratime/releases/download/v${EMERALD_PARATIME_VERSION}/emerald-paratime" "${EMERALD_PARATIME}"
 RUN chmod a+x "${EMERALD_PARATIME}"
+
+# Write VERSION information.
+RUN echo "${VERSION}" > /VERSION
 
 # Install Postgresql and other tools packaged by Ubuntu.
 RUN apt update -qq \

--- a/docker/emerald-dev/Dockerfile
+++ b/docker/emerald-dev/Dockerfile
@@ -43,7 +43,8 @@ RUN chmod a+x "${EMERALD_PARATIME}"
 # Install Postgresql and other tools packaged by Ubuntu.
 RUN apt update -qq \
  && apt dist-upgrade -qq -y \
- && apt install jq postgresql -y
+ && apt install jq postgresql -y \
+ && rm -rf /var/lib/apt/lists/*
 USER postgres
 RUN /etc/init.d/postgresql start \
  && psql --command "ALTER USER postgres WITH SUPERUSER PASSWORD 'postgres';"

--- a/docker/emerald-dev/README.md
+++ b/docker/emerald-dev/README.md
@@ -7,21 +7,34 @@ set up your local development environment for dApps running on Emerald:
 - emerald-web3-gateway
 - oasis-deposit helper to fund your ethereum wallet
 
-To build the docker image, go to your emerald-web3-gateway root folder
-and run:
+## Prebuilt images
+
+Oasis provides prebuilt `emerald-dev` docker images. To run the `latest` version
+based on the `main` branch of `emerald-web3-gateway` repository, run
+
+```sh
+docker run -it -p8545:8545 -p8546:8546 oasisprotocol/emerald-dev
+```
+
+## Build image locally
+
+To build the docker image, go to your `emerald-web3-gateway` repository root
+folder and run:
 
 ```sh
 make docker
 ```
 
-To run the Emerald development environment locally run:
+To run the compiled image type:
 
 ```sh
-docker run -it -p8545:8545 -p8546:8546 emerald-dev
+docker run -it -p8545:8545 -p8546:8546 oasisprotocol/emerald-dev:local
 ```
 
-You can now connect with your hardhat, truffle or metamask to
-http://localhost:8545 or ws://localhost:8546
+## Usage
+
+Once the `emerald-dev` image is up and running, you can connect your hardhat,
+truffle or metamask to http://localhost:8545 or ws://localhost:8546.
 
 By default, a random mnemonic will be generated and the first 5 accounts will
 be funded 100 ROSE. Flags `-amount`, `-to`, `-n` can be added to specify an

--- a/docker/emerald-dev/start-emerald-dev.sh
+++ b/docker/emerald-dev/start-emerald-dev.sh
@@ -4,14 +4,14 @@
 # starts the emerald web3 gateway on top of it, and deposits to a test account on Emerald.
 # Mandatory ENV Variables:
 # - all ENV variables required by spinup-oasis-stack.sh
-# - VERSION: emerald-dev image version
-# - OASIS_CORE_VERSION: version of oasis-node
 # - EMERALD_WEB3_GATEWAY: path to emerald-web3-gateway binary
 # - EMERALD_WEB3_GATEWAY_CONFIG_FILE: path to emerald-web3-gateway config file
 # - OASIS_DEPOSIT: path to oasis-deposit binary
 
-EMERALD_WEB3_GATEWAY_VERSION=$(${EMERALD_WEB3_GATEWAY} -v | head -n1 | cut -d " " -f 3)
-echo "emerald-dev v${VERSION} (oasis-core: v${OASIS_CORE_VERSION}, emerald-paratime: v${EMERALD_PARATIME_VERSION}, emerald-web3-gateway: ${EMERALD_WEB3_GATEWAY_VERSION})"
+EMERALD_WEB3_GATEWAY_VERSION=$(${EMERALD_WEB3_GATEWAY} -v | head -n1 | cut -d " " -f 3 | sed -r 's/^v//')
+OASIS_CORE_VERSION=$(${OASIS_NODE} -v | head -n1 | cut -d " " -f 3 | sed -r 's/^v//')
+VERSION=$(cat /VERSION)
+echo "emerald-dev ${VERSION} (oasis-core: ${OASIS_CORE_VERSION}, emerald-paratime: ${EMERALD_PARATIME_VERSION}, emerald-web3-gateway: ${EMERALD_WEB3_GATEWAY_VERSION})"
 echo
 
 OASIS_NODE_SOCKET=${OASIS_NODE_DATADIR}/net-runner/network/client-0/internal.sock


### PR DESCRIPTION
Fixes #169:
- builds and deploys new emerald-dev docker image each time main is changed
- emerald-dev docker image is now tagged as `latest` and `latest-year-month-day-gitrevision` scheme on dockerhub or `local` locally
- determines `OASIS_CORE_VERSION` variable from running `oasis-node -v` and emerald-dev `VERSION` from the `/VERSION` file
- cleans up apt cache to reduce image size

Preview:
```
$ docker run -it -p8545:8545 -p8546:8546  oasisprotocol/emerald-dev
Unable to find image 'oasisprotocol/emerald-dev:latest' locally
latest: Pulling from oasisprotocol/emerald-dev
08c01a0ec47e: Already exists 
78ac84db65dd: Pull complete 
816cb97c2e1c: Pull complete 
837f2bc4966a: Pull complete 
22f39acd4039: Pull complete 
a607af86faf6: Pull complete 
c2a51e72e844: Pull complete 
ce9c9ba9ef66: Pull complete 
29ee5277144a: Pull complete 
84d7eccf23d1: Pull complete 
f80826fec668: Pull complete 
bfdcb8c0ec40: Pull complete 
17cbef542ef5: Pull complete 
Digest: sha256:998c864d3668d9814523fc86834fbf9d082bc6abf34da2cc4279b3c4bb12b4bc
Status: Downloaded newer image for oasisprotocol/emerald-dev:latest
emerald-dev 2022-02-21-git3dfbe44 (oasis-core: 21.3.9, emerald-paratime: 6.2.0, emerald-web3-gateway: 1.2.1)

Starting oasis-net-runner with Emerald ParaTime...
Starting postgresql...
Starting emerald-web3-gateway...
Populating account(s) (this might take a moment)...
```