### PR TITLE
indexer: replace failed tx 

### DIFF
--- a/indexer/utils.go
+++ b/indexer/utils.go
@@ -1,7 +1,9 @@
 package indexer
 
 import (
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -302,8 +304,24 @@ func (ib *indexBackend) StoreBlockData(oasisBlock *block.Block, txResults []*cli
 					return err
 				}
 			default:
-				if err = s.Insert(ib.ctx, tx); err != nil {
-					return err
+				earlierTx, earlierTxErr := s.GetTransaction(ib.ctx, tx.Hash)
+				if earlierTxErr != nil {
+					if !errors.Is(earlierTxErr, sql.ErrNoRows) {
+						return err
+					}
+					// First encounter of this tx, continue to upsert.
+				} else {
+					if earlierTx.Status != uint(ethtypes.ReceiptStatusFailed) {
+						ib.logger.Error("duplicate tx",
+							"earlier_tx", earlierTx,
+							"tx", tx,
+						)
+						return fmt.Errorf("duplicate tx hash %s in rounds %d and %d", tx.Hash, earlierTx.Round, tx.Round)
+					}
+					// Replacing a failed encounter of this tx, continue to upsert.
+				}
+				if upsertErr := s.Upsert(ib.ctx, tx); upsertErr != nil {
+					return upsertErr
 				}
 			}
 		}


### PR DESCRIPTION


handle cases where an earlier sighting of a tx failed and a later sighting succeeded
