### PR TITLE
feat: add user-agent logging to key RPCs

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -379,6 +379,7 @@ func (api *PublicAPI) Call(args utils.TransactionArgs, blockNrOrHash ethrpc.Bloc
 	}
 
 	logger.Debug("response", "args", args, "resp", res)
+	logger.Info("executed call", "user_agent", api.ctx.Value("User-Agent"))
 
 	return res, nil
 }
@@ -409,7 +410,10 @@ func (api *PublicAPI) SendRawTransaction(data hexutil.Bytes) (common.Hash, error
 		return ethTx.Hash(), err
 	}
 
-	return ethTx.Hash(), nil
+	txHash := ethTx.Hash()
+	logger.Info("submitted transaction", "user_agent", api.ctx.Value("User-Agent"), "tx_hash", txHash)
+
+	return txHash, nil
 }
 
 // EstimateGas returns an estimate of gas usage for the given transaction .
@@ -457,6 +461,7 @@ func (api *PublicAPI) EstimateGas(args utils.TransactionArgs, blockNum *ethrpc.B
 	}
 
 	logger.Debug("result", "gas", gas)
+	logger.Info("estimated gas", "user_agent", api.ctx.Value("User-Agent"))
 
 	return hexutil.Uint64(gas), nil
 }


### PR DESCRIPTION
This PR causes the user-agent to be logged at the info level for `sendRawTransaction`, `Call`, and `EstimateGas` RPCs. This will help us optimize the experience for the most common clients.

The `User-Agent` is added to the `Context` by [go-ethereum](https://github.com/ethereum/go-ethereum/blame/514ae7cfa35b9db671b8271419add728964f0ca6/rpc/http.go#L246-L247). The context key will change if the geth dep is ever updated.