### PR TITLE
fix: add dockerignore to prevent bin shadowing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+emerald-web3-gateway


### PR DESCRIPTION
This PR fixes an issue where the `emerald-web3-gateway` binary existing in the build dir would get used by the final build stage. It's particularly bad if you're on macOS since non-ELF just won't run.

The dockerignore could also be improved so that changes to misc files doesn't bust the docker cache, but that's merely annoying. I seem to be the only person who has this problem, so maybe later :)