### PR TITLE
other(ci): update setup-go action to v3

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -34,6 +34,10 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.x'
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.17"
       - name: Install gitlint
         run: |
           python -m pip install gitlint
@@ -43,10 +47,6 @@ jobs:
         # Always run this step so that all linting errors can be seen at once.
         # Skip this step for dependabot pull requests.
         if: always() && github.actor != 'dependabot[bot]'
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17.x'
       - name: Lint Go
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -46,10 +46,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v2.2.0
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
-          go-version: "1.17.x"
+          go-version: "1.17"
 
       - name: Install prerequisites
         run: |


### PR DESCRIPTION
Also move `Setup Go` step before any lints, so that it gets run even if some of the lints fail (e.g. here https://github.com/oasisprotocol/emerald-web3-gateway/runs/5756403215?check_suite_focus=true)