### PR TITLE
feat(indexer): Improve cache memory efficiency

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -79,10 +79,6 @@ func (cfg *LogConfig) Validate() error {
 type CacheConfig struct {
 	// BlockSize is the size of the block cache in BLOCKS.
 	BlockSize uint64 `koanf:"block_size"`
-	// TxSize is the size of the transaction cache in bytes.
-	TxSize uint64 `koanf:"tx_size"`
-	// TxReceiptSize is the size of the transaction receipt cache in bytes.
-	TxReceiptSize uint64 `koanf:"tx_receipt_size"`
 	// Metrics enables the cache metrics collection.
 	Metrics bool `koanf:"metrics"`
 }

--- a/conf/server.yml
+++ b/conf/server.yml
@@ -10,8 +10,6 @@ log:
 
 cache:
   block_size: 1024
-  tx_size: 1073741824
-  tx_receipt_size: 1073741824
   metrics: false
 
 database:

--- a/conf/tests.yml
+++ b/conf/tests.yml
@@ -7,8 +7,6 @@ log:
 
 cache:
   block_size: 10
-  tx_size: 10485760
-  tx_receipt_size: 10485760
   metrics: true
 
 database:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/oasisprotocol/emerald-web3-gateway
 go 1.17
 
 require (
-	github.com/dgraph-io/ristretto v0.1.0
 	github.com/ethereum/go-ethereum v1.10.10-0.20211005163353-57ff2dee06a1
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/gorilla/mux v1.8.0
@@ -32,7 +31,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/eapache/channels v1.1.0 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
@@ -41,7 +39,6 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/hashicorp/go-hclog v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,7 +268,6 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=
-github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=

--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -93,8 +93,9 @@ type Backend interface {
 
 // BlockData contains all per block indexed data.
 type BlockData struct {
-	Block    *model.Block
-	Receipts []*model.Receipt
+	Block      *model.Block
+	Receipts   []*model.Receipt
+	UniqueTxes []*model.Transaction
 	// LastTransactionPrice is the price of the last transaction in the runtime block in base units.
 	// This can be different than the price of the last transaction in the `BlockData.Block`
 	// as `BlockData.Block` contains only EVM transactions.

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -326,11 +326,7 @@ func New(
 	cfg *conf.Config,
 ) (*Service, Backend, error) {
 	ctx, cancelCtx := context.WithCancel(ctxBackend)
-	cachingBackend, err := newCachingBackend(ctx, backend, cfg.Cache)
-	if err != nil {
-		cancelCtx()
-		return nil, nil, err
-	}
+	cachingBackend := newCachingBackend(ctx, backend, cfg.Cache)
 
 	s := &Service{
 		BaseBackgroundService: *service.NewBaseBackgroundService("gateway/indexer"),

--- a/indexer/utils.go
+++ b/indexer/utils.go
@@ -449,7 +449,12 @@ func (ib *indexBackend) StoreBlockData(ctx context.Context, oasisBlock *block.Bl
 	ib.subscribe.ChainChan() <- chainEvent
 	ib.logger.Debug("sent chain event to event system", "height", blockNum)
 
-	bd := &BlockData{Block: blk, Receipts: upsertedReceipts, LastTransactionPrice: lastTransactionPrice}
+	bd := &BlockData{
+		Block:                blk,
+		Receipts:             upsertedReceipts,
+		UniqueTxes:           upsertedTxes,
+		LastTransactionPrice: lastTransactionPrice,
+	}
 
 	// Notify the observer if any.
 	if ib.observer != nil {


### PR DESCRIPTION
Instead of using a complicated cache implementation, just use a handful
of sync.Maps along with a "remove eldest" replacement policy.  Since our
critical-path access patterns are overwhelmingly for temporally recent data
the new policy also makes it impossible for the hot dataset to be evicted.

Implements #252 