### PR TITLE
feat: add (dummy) eth_syncing implementation

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -101,6 +101,9 @@ type API interface {
 	Mining() bool
 	// Hashrate returns the current node's hashrate.
 	Hashrate() hexutil.Uint64
+	// Syncing returns false in case the node is currently not syncing with the network, otherwise
+	// returns syncing information.
+	Syncing(ctx context.Context) (interface{}, error)
 }
 
 type publicAPI struct {
@@ -692,6 +695,13 @@ func (api *publicAPI) Hashrate() hexutil.Uint64 {
 	logger := api.Logger.With("method", "eth_hashrate")
 	logger.Debug("request")
 	return 0
+}
+
+func (api *publicAPI) Syncing(ctx context.Context) (interface{}, error) {
+	logger := api.Logger.With("method", "eth_syncing")
+	logger.Debug("request")
+
+	return false, nil
 }
 
 // getBlockRound returns the block round from BlockNumberOrHash.

--- a/rpc/eth/metrics/api.go
+++ b/rpc/eth/metrics/api.go
@@ -312,6 +312,15 @@ func (m *metricsWrapper) SendRawTransaction(ctx context.Context, data hexutil.By
 	return
 }
 
+// Syncing implements eth.API.
+func (m *metricsWrapper) Syncing(ctx context.Context) (res interface{}, err error) {
+	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_syncing")
+	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
+
+	res, err = m.api.Syncing(ctx)
+	return
+}
+
 // NewMetricsWrapper returns an instrumanted API service.
 func NewMetricsWrapper(api eth.API, logger *logging.Logger, backend indexer.Backend) eth.API {
 	return &metricsWrapper{


### PR DESCRIPTION
Adds a (dummy) implementation for https://eth.wiki/json-rpc/API#eth_syncing

Always reports as not-syncing (meaning the node is synced up and running normally) for now.

To properly implement this, a method would need to be added to the oasis-core runtime client which would report runtime sync status (latest storage finalized round, and latest known round). This could be obtained via the `control status`, but don't really want to be querying that from the gateway.

I also question the usefulness of this method, since there is nothing wrong by querying a node that is still syncing (it just won't contain recent blocks). And a separate method for health check endpoint already exists.

As far as I can tell, Infura also always returns `false`.