### PR TITLE
feat: Add a way to follow a SQL db instead of indexing

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -22,8 +22,9 @@ type Config struct {
 	// blocks that the node doesn't have data for, such as by skipping them in checkpoint sync.
 	// For sensible reasons, indexing may actually start at an even later block, such as if
 	// this block is already indexed or the node indicates that it doesn't have this block.
-	IndexingStart   uint64 `koanf:"indexing_start"`
-	IndexingDisable bool   `koanf:"indexing_disable"`
+	IndexingStart     uint64 `koanf:"indexing_start"`
+	IndexingDisable   bool   `koanf:"indexing_disable"`
+	IndexingSQLFollow bool   `koanf:"indexing_sql_follow"`
 
 	Log      *LogConfig      `koanf:"log"`
 	Cache    *CacheConfig    `koanf:"cache"`

--- a/main.go
+++ b/main.go
@@ -195,7 +195,7 @@ func runRoot() error {
 	// For now, "disable" write access to the DB in a kind of kludgy way
 	// if the indexer is disabled.  Yes this means that no migrations
 	// can be done.  Deal with it.
-	dbReadOnly := cfg.IndexingDisable
+	dbReadOnly := cfg.IndexingDisable || cfg.IndexingSQLFollow
 
 	// Initialize db for migrations (higher timeouts).
 	db, err := psql.InitDB(ctx, cfg.Database, true, dbReadOnly)


### PR DESCRIPTION
This should allow multiple non-archival instances to share the same
database, with one and only one instance writing to the db.

Fixes: #84