### PR TITLE
feat: update to oasis-core 22.1.8

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      OASIS_CORE_VERSION: "22.1.7"
+      OASIS_CORE_VERSION: "22.1.8"
       OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
       EMERALD_PARATIME_VERSION: 9.0.1-testnet

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -35,7 +35,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      OASIS_CORE_VERSION: "22.1.7"
+      OASIS_CORE_VERSION: "22.1.8"
       OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
       EMERALD_PARATIME_VERSION: 9.0.1-testnet

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Web3 Gateway for Oasis Emerald EVM.
 - [PostgreSQL](https://www.postgresql.org/) (at least version 13.3).
 
 Additionally, for testing:
-- [Oasis Core](https://github.com/oasisprotocol/oasis-core) version 22.1.7.
+- [Oasis Core](https://github.com/oasisprotocol/oasis-core) version 22.1.8.
 - [Emerald Paratime](https://github.com/oasisprotocol/emerald-paratime) version 9.0.1-testnet.
 
 ### Build

--- a/docker/emerald-dev/Dockerfile
+++ b/docker/emerald-dev/Dockerfile
@@ -5,7 +5,7 @@ RUN cd emerald-web3-gateway && make build
 
 FROM ubuntu:20.04
 
-ENV OASIS_CORE_VERSION=22.1.7
+ENV OASIS_CORE_VERSION=22.1.8
 ENV EMERALD_PARATIME_VERSION=9.0.1-testnet
 
 ENV OASIS_NODE=/oasis-node

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -25,39 +25,29 @@ ${OASIS_NET_RUNNER} dump-fixture \
   --fixture.default.deterministic_entities \
   --fixture.default.fund_entities \
   --fixture.default.num_entities 2 \
-  --fixture.default.keymanager.binary "${EMERALD_PARATIME}" \
+  --fixture.default.keymanager.binary "" \
   --fixture.default.runtime.binary "${EMERALD_PARATIME}" \
   --fixture.default.runtime.provisioner "unconfined" \
+  --fixture.default.runtime.version "$(emerald_ver 1).$(emerald_ver 2).$(emerald_ver 3)" \
   --fixture.default.halt_epoch 100000 \
   --fixture.default.staking_genesis "${STAKING_GENESIS_FILE}" >"$FIXTURE_FILE"
 
-# oasis-core 22.0 has a bug where you cannot provision a fixture without a keymanager.
-# When updating to oasis-core 22.1.8 remove below hack and updaate abobe keymanager.binary to "".
-# Disable keymanager for runtime.
-jq '.runtimes[1].keymanager = -1' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
-mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
-
 # Enable expensive queries for testing.
-jq '.clients[0].runtime_config."1".allow_expensive_queries = true' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
-mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
-
-# Assign non-zero version to runtime, otherwise nodes won't register.
-# TODO: Replace with fixture flag once https://github.com/oasisprotocol/oasis-core/pull/4815 is released.
-jq ".runtimes[1].deployments[0].version = {major:"$(emerald_ver 1)", minor:"$(emerald_ver 2)", patch:"$(emerald_ver 3)"}" "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+jq '.clients[0].runtime_config."0".allow_expensive_queries = true' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
 # Bump the batch size (default=1).
-jq '.runtimes[1].txn_scheduler.max_batch_size=20' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+jq '.runtimes[0].txn_scheduler.max_batch_size=20' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
-jq '.runtimes[1].txn_scheduler.max_batch_size_bytes=1048576' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+jq '.runtimes[0].txn_scheduler.max_batch_size_bytes=1048576' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
-jq '.runtimes[1].txn_scheduler.propose_batch_timeout=2' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+jq '.runtimes[0].txn_scheduler.propose_batch_timeout=2' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
 # Use a batch timeout of 1 second.
-jq '.runtimes[1].txn_scheduler.batch_flush_timeout=1000000000' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+jq '.runtimes[0].txn_scheduler.batch_flush_timeout=1000000000' "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
 # Run oasis-node.


### PR DESCRIPTION
The hacks in oasis-net-runner should not be needed anymore with 22.1.8.