### PR TITLE
feat: add oasis_publicKey RPC

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -85,3 +85,75 @@ jobs:
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3.1.0
+
+  test-go-c10l:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_PORT: 5432
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+    env:
+      OASIS_CORE_VERSION: "22.1.9"
+      OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
+      OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
+      EMERALD_PARATIME_VERSION: 0.1.3-testnet
+      GATEWAY__CHAIN_ID: 23295
+      GATEWAY__OASIS_RPCS: true
+      EMERALD_PARATIME: ${{ github.workspace }}/oasis_core/sapphire-paratime
+      KEYMANAGER_ARTIFACT_URL: https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/9098/jobs/01824af5-09bf-4ca0-a645-f63675e87f49/artifacts/01824af8-a4a1-4f17-a598-3be41a165b15 # Find this at https://buildkite.com/oasisprotocol/oasis-core-ci/builds?branch=stable%2F<...> under "Build runtimes".
+      KEYMANAGER_BINARY: ${{ github.workspace }}/oasis_core/simple-keymanager
+      OASIS_NODE_DATADIR: /tmp/eth-runtime-test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.17"
+
+      - name: Install prerequisites
+        run: |
+          sudo apt update && sudo apt install bubblewrap unzip -y
+          # oasis-core
+          wget "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
+          tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
+          mkdir -p "$(dirname ${OASIS_NODE})"
+          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE}"
+          mkdir -p "$(dirname ${OASIS_NET_RUNNER})"
+          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}"
+          mkdir -p "$(dirname ${EMERALD_PARATIME})"
+          # sapphire-paratime
+          wget "https://github.com/oasisprotocol/sapphire-paratime/releases/download/v${EMERALD_PARATIME_VERSION}/insecure-debug-sapphire-paratime.orc" -O "${EMERALD_PARATIME}.orc"
+          unzip "${EMERALD_PARATIME}.orc"
+          mv runtime.elf "${EMERALD_PARATIME}"
+          chmod a+x "${EMERALD_PARATIME}"
+          # simple-keymanager
+          wget "${KEYMANAGER_ARTIFACT_URL}" -O "${KEYMANAGER_BINARY}"
+
+      - name: Spinup oasis-node
+        run: tests/tools/spinup-oasis-stack.sh > /dev/null &
+
+      - name: Unit tests with coverage
+        run: go test -race -coverpkg=./... -coverprofile=coverage.txt -covermode=atomic -v ./...
+
+      - name: Shutdown oasis-node
+        run: killall oasis-node
+        if: always()
+
+      - name: Upload oasis-node logs artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: oasis-node-logs-c10l
+          path: ${{ env.OASIS_NODE_DATADIR }}/**/*.log
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3.1.0

--- a/conf/benchmarks.yml
+++ b/conf/benchmarks.yml
@@ -34,3 +34,4 @@ gateway:
     port: 9999
   method_limits:
     get_logs_max_rounds: 100
+  oasis_rpcs: false

--- a/conf/config.go
+++ b/conf/config.go
@@ -131,6 +131,9 @@ type GatewayConfig struct {
 
 	// MethodLimits is the gateway method limits config.
 	MethodLimits *MethodLimits `koanf:"method_limits"`
+
+	// OasisRPCs controls whether to enable the `oasis_*` methods. Default is not exposed.
+	ExposeOasisRPCs bool `koanf:"oasis_rpcs"`
 }
 
 // GatewayMonitoringConfig is the gateway prometheus configuration.

--- a/conf/server.yml
+++ b/conf/server.yml
@@ -36,3 +36,4 @@ gateway:
     port: 9999
   method_limits:
     get_logs_max_rounds: 100
+  oasis_rpcs: false

--- a/conf/tests.yml
+++ b/conf/tests.yml
@@ -33,3 +33,4 @@ gateway:
     port: 9999
   method_limits:
     get_logs_max_rounds: 100
+  oasis_rpcs: false

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oasisprotocol/emerald-web3-gateway/rpc/eth/filters"
 	ethmetrics "github.com/oasisprotocol/emerald-web3-gateway/rpc/eth/metrics"
 	"github.com/oasisprotocol/emerald-web3-gateway/rpc/net"
+	"github.com/oasisprotocol/emerald-web3-gateway/rpc/oasis"
 	"github.com/oasisprotocol/emerald-web3-gateway/rpc/txpool"
 	"github.com/oasisprotocol/emerald-web3-gateway/rpc/web3"
 )
@@ -37,6 +38,7 @@ func GetRPCAPIs(
 	netService := net.NewPublicAPI(config.ChainID)
 	txpoolService := txpool.NewPublicAPI()
 	filtersService := filters.NewPublicAPI(client, logging.GetLogger("eth_filters"), backend, eventSystem)
+	oasisService := oasis.NewPublicAPI(client, logging.GetLogger("oasis"))
 
 	if config.Monitoring.Enabled() {
 		web3Service = web3.NewMetricsWrapper(web3Service)
@@ -44,6 +46,7 @@ func GetRPCAPIs(
 		ethService = ethmetrics.NewMetricsWrapper(ethService, logging.GetLogger("eth_rpc_metrics"), backend)
 		txpoolService = txpool.NewMetricsWrapper(txpoolService)
 		filtersService = filters.NewMetricsWrapper(filtersService)
+		oasisService = oasis.NewMetricsWrapper(oasisService)
 	}
 
 	apis = append(apis,
@@ -76,6 +79,12 @@ func GetRPCAPIs(
 			Version:   "1.0",
 			Service:   filtersService,
 			Public:    true,
+		},
+		ethRpc.API{
+			Namespace: "oasis",
+			Version:   "1.0",
+			Service:   oasisService,
+			Public:    config.ExposeOasisRPCs,
 		},
 	)
 

--- a/rpc/oasis/api.go
+++ b/rpc/oasis/api.go
@@ -1,0 +1,41 @@
+package oasis
+
+import (
+	"context"
+	"errors"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
+)
+
+var ErrInternalError = errors.New("internal error")
+
+// API is the net_ prefixed set of APIs in the Web3 JSON-RPC spec.
+type API interface {
+	// CallDataPublicKey returns the calldata public key for the runtime with the provided ID.
+	CallDataPublicKey(ctx context.Context) (*core.CallDataPublicKeyResponse, error)
+}
+
+type publicAPI struct {
+	client client.RuntimeClient
+	Logger *logging.Logger
+}
+
+// NewPublicAPI creates an instance of the Web3 API.
+func NewPublicAPI(
+	client client.RuntimeClient,
+	logger *logging.Logger,
+) API {
+	return &publicAPI{client: client, Logger: logger}
+}
+
+func (api *publicAPI) CallDataPublicKey(ctx context.Context) (*core.CallDataPublicKeyResponse, error) {
+	logger := api.Logger.With("method", "oasis_callDataPublicKey")
+	res, err := core.NewV1(api.client).CallDataPublicKey(ctx)
+	if err != nil {
+		logger.Error("failed to fetch public key", "err", err)
+		return nil, ErrInternalError
+	}
+	return res, nil
+}

--- a/rpc/oasis/metrics.go
+++ b/rpc/oasis/metrics.go
@@ -1,0 +1,27 @@
+package oasis
+
+import (
+	"context"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
+
+	"github.com/oasisprotocol/emerald-web3-gateway/rpc/metrics"
+)
+
+type metricsWrapper struct {
+	api API
+}
+
+// PublicKey implements API.
+func (m *metricsWrapper) CallDataPublicKey(ctx context.Context) (*core.CallDataPublicKeyResponse, error) {
+	r, s, f, i, d := metrics.GetAPIMethodMetrics("oasis_callDataPublicKey")
+	defer metrics.InstrumentCaller(r, s, f, i, d, nil)()
+	return m.api.CallDataPublicKey(ctx)
+}
+
+// NewMetricsWrapper returns an instrumanted API service.
+func NewMetricsWrapper(api API) API {
+	return &metricsWrapper{
+		api,
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -218,7 +218,7 @@ func (srv *Web3Gateway) startRPC() error {
 	// Configure HTTP.
 	if srv.config.HTTP != nil {
 		config := httpConfig{
-			Modules:            []string{"net", "web3", "eth", "txpool"},
+			Modules:            []string{"net", "web3", "eth", "txpool", "oasis"},
 			CorsAllowedOrigins: srv.config.HTTP.Cors,
 			Vhosts:             srv.config.HTTP.VirtualHosts,
 			prefix:             srv.config.HTTP.PathPrefix,
@@ -234,7 +234,7 @@ func (srv *Web3Gateway) startRPC() error {
 	// Configure WebSocket.
 	if srv.config.WS != nil {
 		config := wsConfig{
-			Modules: []string{"net", "web3", "eth", "txpool"},
+			Modules: []string{"net", "web3", "eth", "txpool", "oasis"},
 			Origins: srv.config.WS.Origins,
 			prefix:  srv.config.WS.PathPrefix,
 		}

--- a/tests/rpc/oasis_test.go
+++ b/tests/rpc/oasis_test.go
@@ -1,0 +1,25 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/emerald-web3-gateway/tests"
+)
+
+func TestOasis_CallDataPublicKey(t *testing.T) {
+	if !tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("oasis RPCs are not enabled")
+		return
+	}
+	rpcRes := call(t, "oasis_callDataPublicKey", []string{})
+	var res core.CallDataPublicKeyResponse
+	err := json.Unmarshal(rpcRes.Result, &res)
+	require.NoError(t, err)
+	require.Len(t, res.PublicKey.PublicKey, 32)
+	require.NotEmpty(t, res.PublicKey.Checksum)
+	require.NotEmpty(t, res.PublicKey.Signature)
+}

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -166,7 +166,7 @@ func TestEth_GetBlockByNumberAndGetBlockByHash(t *testing.T) {
 	require.Equal(t, number, blk1.Number())
 
 	// Ensure block gas limit is correct.
-	require.EqualValues(t, 10_000_000, blk1.GasLimit(), "expected block gas limit")
+	require.True(t, blk1.GasLimit() == 10_000_000 || blk1.GasLimit() == 30_000_000, "expected block gas limit")
 
 	// go-ethereum's Block struct always computes block hash on-the-fly
 	// instead of simply returning the hash from BlockBy* API responses.
@@ -245,6 +245,10 @@ func TestEth_BlockNumber(t *testing.T) {
 }
 
 func TestEth_GetTransactionByHash(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()
 
@@ -278,6 +282,10 @@ func TestEth_GetTransactionByHash(t *testing.T) {
 }
 
 func TestEth_GetTransactionByBlockAndIndex(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()
 
@@ -311,6 +319,10 @@ func TestEth_GetTransactionByBlockAndIndex(t *testing.T) {
 }
 
 func TestEth_GetBlockByHashRawResponses(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()
 
@@ -348,6 +360,10 @@ func TestEth_GetBlockByHashRawResponses(t *testing.T) {
 }
 
 func TestEth_GetTransactionReceiptRawResponses(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()
 
@@ -437,6 +453,10 @@ func TestEth_GetLogsWithFilters(t *testing.T) {
 }
 
 func TestEth_GetLogsMultiple(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()
 	ec := localClient(t, false)

--- a/tests/rpc/subscribe_test.go
+++ b/tests/rpc/subscribe_test.go
@@ -39,6 +39,10 @@ func TestEth_SubscribeNewHead(t *testing.T) {
 }
 
 func TestEth_SubscribeLogs(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
 	defer cancel()
 

--- a/tests/rpc/tx_test.go
+++ b/tests/rpc/tx_test.go
@@ -128,16 +128,28 @@ func testContractCreation(t *testing.T, value *big.Int) uint64 {
 }
 
 func TestContractCreation(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	status := testContractCreation(t, big.NewInt(0))
 	require.Equal(t, uint64(1), status)
 }
 
 func TestContractFailCreation(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	status := testContractCreation(t, big.NewInt(1))
 	require.Equal(t, uint64(0), status)
 }
 
 func TestEth_EstimateGas(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ec := localClient(t, false)
 	code := common.FromHex(strings.TrimSpace(evmSolTestCompiledHex))
 
@@ -187,6 +199,10 @@ func TestEth_EstimateGas(t *testing.T) {
 }
 
 func TestEth_GetCode(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	ec := localClient(t, false)
 
 	code := common.FromHex(strings.TrimSpace(evmSolTestCompiledHex))
@@ -227,6 +243,10 @@ func TestEth_GetCode(t *testing.T) {
 }
 
 func TestEth_Call(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	abidata := `
 		[
 			{
@@ -311,6 +331,10 @@ func TestEth_Call(t *testing.T) {
 // 	   }
 //   }
 func TestERC20(t *testing.T) {
+	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
+		t.Skip("contract tests w/ c10lity require compat lib to be integrated")
+		return
+	}
 	testabi, _ := abi.JSON(strings.NewReader(erc20abi))
 
 	ec := localClient(t, false)

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -25,7 +25,7 @@ ${OASIS_NET_RUNNER} dump-fixture \
   --fixture.default.deterministic_entities \
   --fixture.default.fund_entities \
   --fixture.default.num_entities 2 \
-  --fixture.default.keymanager.binary "" \
+  --fixture.default.keymanager.binary "${KEYMANAGER_BINARY:-}" \
   --fixture.default.runtime.binary "${EMERALD_PARATIME}" \
   --fixture.default.runtime.provisioner "unconfined" \
   --fixture.default.runtime.version "$(emerald_ver 1).$(emerald_ver 2).$(emerald_ver 3)" \


### PR DESCRIPTION
This PR adds an optional method `oasis_publicKey` that returns the attached runtime's calldata public key. This is helpful for Web3 clients that don't want to also connect directly to GRPC.