### PR TITLE
other: encode oasis_callDataPublicKey as hex

### DIFF
--- a/rpc/oasis/api.go
+++ b/rpc/oasis/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
@@ -14,7 +15,19 @@ var ErrInternalError = errors.New("internal error")
 // API is the net_ prefixed set of APIs in the Web3 JSON-RPC spec.
 type API interface {
 	// CallDataPublicKey returns the calldata public key for the runtime with the provided ID.
-	CallDataPublicKey(ctx context.Context) (*core.CallDataPublicKeyResponse, error)
+	CallDataPublicKey(ctx context.Context) (*CallDataPublicKey, error)
+}
+
+// CallDataPublicKey is the public key alongside the key manager's signature.
+//
+// This is a flattened `core.CallDataPublicKeyResponse` with hex-encoded bytes for easy consumption by Web3 clients.
+type CallDataPublicKey struct {
+	// PublicKey is the requested public key.
+	PublicKey hexutil.Bytes `json:"key"`
+	// Checksum is the checksum of the key manager state.
+	Checksum hexutil.Bytes `json:"checksum"`
+	// Signature is the Sign(sk, (key || checksum)) from the key manager.
+	Signature hexutil.Bytes `json:"signature"`
 }
 
 type publicAPI struct {
@@ -30,12 +43,16 @@ func NewPublicAPI(
 	return &publicAPI{client: client, Logger: logger}
 }
 
-func (api *publicAPI) CallDataPublicKey(ctx context.Context) (*core.CallDataPublicKeyResponse, error) {
+func (api *publicAPI) CallDataPublicKey(ctx context.Context) (*CallDataPublicKey, error) {
 	logger := api.Logger.With("method", "oasis_callDataPublicKey")
 	res, err := core.NewV1(api.client).CallDataPublicKey(ctx)
 	if err != nil {
 		logger.Error("failed to fetch public key", "err", err)
 		return nil, ErrInternalError
 	}
-	return res, nil
+	return &CallDataPublicKey{
+		PublicKey: res.PublicKey.PublicKey[:],
+		Checksum:  res.PublicKey.Checksum,
+		Signature: res.PublicKey.Signature[:],
+	}, nil
 }

--- a/rpc/oasis/metrics.go
+++ b/rpc/oasis/metrics.go
@@ -3,8 +3,6 @@ package oasis
 import (
 	"context"
 
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
-
 	"github.com/oasisprotocol/emerald-web3-gateway/rpc/metrics"
 )
 
@@ -13,7 +11,7 @@ type metricsWrapper struct {
 }
 
 // PublicKey implements API.
-func (m *metricsWrapper) CallDataPublicKey(ctx context.Context) (*core.CallDataPublicKeyResponse, error) {
+func (m *metricsWrapper) CallDataPublicKey(ctx context.Context) (*CallDataPublicKey, error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("oasis_callDataPublicKey")
 	defer metrics.InstrumentCaller(r, s, f, i, d, nil)()
 	return m.api.CallDataPublicKey(ctx)

--- a/tests/rpc/oasis_test.go
+++ b/tests/rpc/oasis_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/emerald-web3-gateway/rpc/oasis"
 	"github.com/oasisprotocol/emerald-web3-gateway/tests"
 )
 
@@ -16,10 +16,10 @@ func TestOasis_CallDataPublicKey(t *testing.T) {
 		return
 	}
 	rpcRes := call(t, "oasis_callDataPublicKey", []string{})
-	var res core.CallDataPublicKeyResponse
+	var res oasis.CallDataPublicKey
 	err := json.Unmarshal(rpcRes.Result, &res)
 	require.NoError(t, err)
-	require.Len(t, res.PublicKey.PublicKey, 32)
-	require.NotEmpty(t, res.PublicKey.Checksum)
-	require.NotEmpty(t, res.PublicKey.Signature)
+	require.Len(t, res.PublicKey, 32)
+	require.NotEmpty(t, res.Checksum)
+	require.NotEmpty(t, res.Signature)
 }


### PR DESCRIPTION
I was feeling overconfident in my ability to decode base64 in JS, so now it's hex.