### PR TITLE
Drop unencrypted transactions by default

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -134,6 +134,9 @@ type GatewayConfig struct {
 
 	// OasisRPCs controls whether to enable the `oasis_*` methods. Default is not exposed.
 	ExposeOasisRPCs bool `koanf:"oasis_rpcs"`
+
+	// AllowUnencryptedTxs also accepts transacions with CallFormat=0. Default is false.
+	AllowUnencryptedTxs bool `koanf:"allow_unencrypted_txs"`
 }
 
 // GatewayMonitoringConfig is the gateway prometheus configuration.

--- a/conf/tests-c10l.yml
+++ b/conf/tests-c10l.yml
@@ -1,16 +1,13 @@
 runtime_id: "8000000000000000000000000000000000000000000000000000000000000000"
 node_address: "unix:/tmp/eth-runtime-test/net-runner/network/client-0/internal.sock"
-enable_pruning: false
-pruning_step: 100000
-indexing_start: 0
 
 log:
   level: debug
   format: json
 
 cache:
-  block_size: 1024
-  metrics: false
+  block_size: 10
+  metrics: true
 
 database:
   host: "127.0.0.1"
@@ -32,9 +29,10 @@ gateway:
     host: "localhost"
     port: 8546
   monitoring:
-    host: "" # Disabled.
+    host: "localhost"
     port: 9999
   method_limits:
     get_logs_max_rounds: 100
   oasis_rpcs: true
   allow_unencrypted_txs: false
+

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -34,7 +34,7 @@ func GetRPCAPIs(
 	var apis []ethRpc.API
 
 	web3Service := web3.NewPublicAPI()
-	ethService := eth.NewPublicAPI(client, archiveClient, logging.GetLogger("eth_rpc"), config.ChainID, backend, gasPriceOracle, config.MethodLimits)
+	ethService := eth.NewPublicAPI(client, archiveClient, logging.GetLogger("eth_rpc"), config.ChainID, backend, gasPriceOracle, config.MethodLimits, !config.ExposeOasisRPCs || config.AllowUnencryptedTxs)
 	netService := net.NewPublicAPI(config.ChainID)
 	txpoolService := txpool.NewPublicAPI()
 	filtersService := filters.NewPublicAPI(client, logging.GetLogger("eth_filters"), backend, eventSystem)


### PR DESCRIPTION
This PR:
- drops unencrypted eth transaction, if Oasis RPC is enabled (e.g. sapphire) and the data is a wrapped Oasis transaction with CallFormat==Plain
- adds `gateway.allow_unencrypted_txs` flag to config which enables accepting unencrypted transactions
- adds `conf/tests-c10l.yml` and use it in Sapphire e2e tests
- enables Oasis RPC in default `server.yml` config