### PR TITLE
Upgrade sapphire-dev container to Sapphire 0.5.2 and oasis-core 22.2.8

### DIFF
--- a/docker/sapphire-dev/Dockerfile
+++ b/docker/sapphire-dev/Dockerfile
@@ -17,8 +17,8 @@ RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch stable/22
 FROM ubuntu:22.04
 
 # Docker-specific variables
-ENV OASIS_CORE_VERSION=22.2.6
-ENV PARATIME_VERSION=0.4.0
+ENV OASIS_CORE_VERSION=22.2.8
+ENV PARATIME_VERSION=0.5.2
 ENV PARATIME_NAME=sapphire
 ENV GATEWAY__CHAIN_ID=0x5afd
 


### PR DESCRIPTION
This is necessary so developers who want to develop locally have access to the latest stable version of Sapphire.

Without this upgrade, developers will get weird & mysterious problems if they try to use some of the newer precompiles as they're not supported on 0.4.0.

While the https://github.com/oasisprotocol/oasis-web3-gateway/pkgs/container/sapphire-dev container has been updated recently, it does not include Sapphire 0.5.2