### PR TITLE
other: dependabot: group 'bun' updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
       # Oasis dependencies are manually updated.
       - dependency-name: github.com/oasisprotocol/oasis-core/go
       - dependency-name: github.com/oasisprotocol/oasis-sdk/client-sdk/go
+    groups:
+      # Group bun updates into a single PR as there are three bun packages
+      # that need to be updated simultaneously.
+      bun:
+        - "github.com/uptrace/bun"
+        - "github.com/uptrace/bun/dialect/pgdialect"
+        - "github.com/uptrace/bun/driver/pgdriver"
+


### PR DESCRIPTION
Hopefully this works as advertised: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

There are 3 bun packages that need to be updated in the same PR. Before, I was doing this manually, this should handle it automatically. 


Note: could use this group feature in other repos as well to reduce the amount of PR's dependabot opens, and group multiple minor updates into a single PR.