### PR TITLE
feat(docker): Bump sapphire 0.7.0-testnet and emerald 11.0.0-testnet

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -50,7 +50,7 @@ Chain IDs:
 - Sapphire Localnet: `0x5afd` (`23293`)
 
 By default, a random mnemonic will be generated and the first 5 accounts will
-be funded 100 ROSE. Flags `-amount`, `-to`, `-n` can be added to specify an
+be funded 10,000 TEST. Flags `-amount`, `-to`, `-n` can be added to specify an
 initial ROSE deposit, existing mnemonic and the number of addresses to derive
 and fund respectively.
 

--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -52,25 +52,24 @@ while ! [[ -S ${OASIS_NODE_SOCKET} ]]; do sleep 1; done
 ${OASIS_WEB3_GATEWAY} --config ${OASIS_WEB3_GATEWAY_CONFIG_FILE} 2>1 &>/var/log/oasis-web3-gateway.log &
 OASIS_WEB3_GATEWAY_PID=$!
 
+# Wait for compute nodes before initiating deposit.
+echo -n " * Bootstrapping network (this might take a minute)"
 if [[ ${SAPPHIRE_BACKEND} == 'mock' ]]; then
-	echo -n " * Bootstrapping network (this might take a minute)"
-
 	echo -n .
 	${OASIS_NODE} debug control wait-nodes -n 2 -a unix:${OASIS_NODE_SOCKET}
 
 	echo -n .
 	${OASIS_NODE} debug control set-epoch --epoch 1 -a unix:${OASIS_NODE_SOCKET}
 
-	echo .
+	echo -n .
 	${OASIS_NODE} debug control set-epoch --epoch 2 -a unix:${OASIS_NODE_SOCKET}
 else
-	echo " * Bootstrapping network (this might take a minute)"
-	# Wait for compute nodes before initiating deposit.
 	${OASIS_NODE} debug control wait-ready -a unix:${OASIS_NODE_SOCKET}
 fi
 
+echo
 echo " * Populating accounts"
-echo ""
+echo
 ${OASIS_DEPOSIT} -sock unix:${OASIS_NODE_SOCKET} "$@"
 
 echo

--- a/docker/emerald-dev/Dockerfile
+++ b/docker/emerald-dev/Dockerfile
@@ -8,8 +8,8 @@ RUN cd oasis-web3-gateway && make build
 FROM ubuntu:22.04
 
 # Docker-specific variables
-ENV OASIS_CORE_VERSION=22.2.6
-ENV PARATIME_VERSION=10.0.0
+ENV OASIS_CORE_VERSION=23.0.1
+ENV PARATIME_VERSION=11.0.0-testnet
 ENV PARATIME_NAME=emerald
 ENV GATEWAY__CHAIN_ID=0xa514
 

--- a/docker/sapphire-dev/Dockerfile
+++ b/docker/sapphire-dev/Dockerfile
@@ -5,11 +5,11 @@ COPY . /go/oasis-web3-gateway
 RUN cd oasis-web3-gateway && make build
 
 # Build simple-keymanager
-FROM oasisprotocol/oasis-core-dev:stable-22.2.x AS oasis-core-dev
+FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-23.0.x AS oasis-core-dev
 
 ENV OASIS_UNSAFE_SKIP_KM_POLICY=1
 
-RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch stable/22.2.x --depth 1 \
+RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch stable/23.0.x --depth 1 \
 	&& cd oasis-core/tests/runtimes/simple-keymanager \
 	&& cargo build
 
@@ -34,8 +34,8 @@ RUN apt update -qq \
 
 # Docker-specific variables
 ENV OASIS_CORE_VERSION=23.0.1
-ENV OASIS_CLI_VERSION=0.5.0
-ENV PARATIME_VERSION=0.6.4
+ENV OASIS_CLI_VERSION=0.6.0
+ENV PARATIME_VERSION=0.7.0-testnet
 ENV PARATIME_NAME=sapphire
 ENV GATEWAY__CHAIN_ID=0x5afd
 


### PR DESCRIPTION
This PR bumps the runtimes used in the docker images:
- Sapphire ParaTime to 0.7.0-testnet
- Emerald ParaTime to 11.0.0-testnet
- oasis-core-dev to the new 23.0.x branch living on ghcr.io
- simple-keymanager to the new stable/23.0.x branch

Also fixes the default deposit amount mentioned in README to 10,000 TEST as it should be from the beginning (compatible with the Hardhat's node).

Followup to https://github.com/oasisprotocol/oasis-web3-gateway/pull/460