### PR TITLE
fix: sapphire-dev: Fix key manager initialization

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -38,8 +38,8 @@ jobs:
       OASIS_CORE_VERSION: "23.0.1"
       OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
-      EMERALD_PARATIME_VERSION: 10.0.0
-      GATEWAY__CHAIN_ID: 42262
+      EMERALD_PARATIME_VERSION: 11.0.0-testnet
+      GATEWAY__CHAIN_ID: 42260
       EMERALD_PARATIME: ${{ github.workspace }}/oasis_core/emerald-paratime
       OASIS_NODE_DATADIR: /tmp/eth-runtime-test
     steps:
@@ -61,7 +61,7 @@ jobs:
           mkdir -p "$(dirname ${OASIS_NET_RUNNER})"
           mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}"
           mkdir -p "$(dirname ${EMERALD_PARATIME})"
-          wget "https://github.com/oasisprotocol/emerald-paratime/releases/download/v${EMERALD_PARATIME_VERSION}/emerald-paratime.orc" -O "${EMERALD_PARATIME}.orc"
+          wget "https://github.com/oasisprotocol/emerald-paratime/releases/download/v${EMERALD_PARATIME_VERSION}/localnet-emerald-paratime.orc" -O "${EMERALD_PARATIME}.orc"
           unzip "${EMERALD_PARATIME}.orc"
           mv runtime.elf "${EMERALD_PARATIME}"
           chmod a+x "${EMERALD_PARATIME}"
@@ -109,7 +109,7 @@ jobs:
       OASIS_CORE_VERSION: "23.0.1"
       OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
-      SAPPHIRE_PARATIME_VERSION: 0.6.4
+      SAPPHIRE_PARATIME_VERSION: 0.7.0-testnet
       GATEWAY__CHAIN_ID: 23293
       GATEWAY__OASIS_RPCS: true
       SAPPHIRE_PARATIME: ${{ github.workspace }}/oasis_core/sapphire-paratime

--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   docker:
@@ -33,7 +36,24 @@ jobs:
         run: |
           echo "VERSION=$(date +%Y-%m-%d-git$(git rev-parse --short HEAD))" >> $GITHUB_ENV
 
-      - name: Build and push
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            VERSION=${{ env.VERSION }}
+          context: .
+          file: docker/${{ matrix.docker_image }}/Dockerfile
+          tags: |
+            ghcr.io/oasisprotocol/${{ matrix.docker_image }}:local
+          load: true
+
+      - name: Test
+        timeout-minutes: 5
+        working-directory: docker/${{ matrix.docker_image }}
+        run: ./test.sh
+
+      - name: Push
+        if: ${{ github.event_name == 'push' }}
         uses: docker/build-push-action@v5
         with:
           build-args: |
@@ -49,6 +69,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Prune old ghcr.io/oasisprotocol/${{ matrix.docker_image }} images
+        if: ${{ github.event_name == 'push' }}
         uses: vlaurin/action-ghcr-prune@v0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -25,6 +25,7 @@ export SAPPHIRE_BACKEND=default
 fi
 
 OASIS_NODE_SOCKET=${OASIS_NODE_DATADIR}/net-runner/network/client-0/internal.sock
+OASIS_KM_SOCKET=${OASIS_NODE_DATADIR}/net-runner/network/keymanager-0/internal.sock
 
 set -euo pipefail
 
@@ -63,6 +64,13 @@ if [[ ${SAPPHIRE_BACKEND} == 'mock' ]]; then
 
 	echo -n .
 	${OASIS_NODE} debug control set-epoch --epoch 2 -a unix:${OASIS_NODE_SOCKET}
+
+	# Transition to the final epoch when the KM generates ephemeral secret.
+	while (${OASIS_NODE} control status -a unix:${OASIS_KM_SOCKET} | jq -e ".keymanager.worker.ephemeral_secrets.last_generated_epoch!=3" >/dev/null); do
+		sleep 0.5
+	done
+	echo -n .
+	${OASIS_NODE} debug control set-epoch --epoch 3 -a unix:${OASIS_NODE_SOCKET}
 else
 	${OASIS_NODE} debug control wait-ready -a unix:${OASIS_NODE_SOCKET}
 fi

--- a/docker/emerald-dev/Dockerfile
+++ b/docker/emerald-dev/Dockerfile
@@ -9,6 +9,7 @@ FROM ubuntu:22.04
 
 # Docker-specific variables
 ENV OASIS_CORE_VERSION=23.0.1
+ENV OASIS_CLI_VERSION=0.6.0
 ENV PARATIME_VERSION=11.0.0-testnet
 ENV PARATIME_NAME=emerald
 ENV GATEWAY__CHAIN_ID=0xa514
@@ -29,8 +30,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install Postgresql and other tools packaged by Ubuntu.
 RUN apt update -qq \
 	&& apt dist-upgrade -qq -y \
-	&& apt install jq postgresql unzip -y \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt install jq postgresql unzip ca-certificates wget -y \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& echo "" \
+	&& echo "Initialize PostgreSQL database, permissions need to be setup" \
+	&& chown -R postgres:postgres /etc/postgresql /var/run/postgresql /var/log/postgresql /var/lib/postgresql/ \
+	&& chown postgres:ssl-cert /etc/ssl/private/ \
+	&& chown postgres:postgres /etc/ssl/private/ssl-cert-snakeoil.key \
+	&& chmod 600               /etc/ssl/private/ssl-cert-snakeoil.key  \
+	&& /etc/init.d/postgresql start \
+	&& su -c "psql --command \"ALTER USER postgres WITH SUPERUSER PASSWORD 'postgres';\"" postgres
 
 # oasis-web3-gateway binary, config, spinup-* scripts and staking_genesis.json.
 COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY}
@@ -40,24 +49,30 @@ COPY docker/common/start.sh /
 COPY tests/tools/* /
 
 # Configure oasis-node and oasis-net-runner.
-ADD "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" /
-RUN tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
+RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"  \
+    && tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
 	&& mkdir -p "$(dirname ${OASIS_NODE})" "$(dirname ${OASIS_NET_RUNNER})" \
 	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE}" \
-	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}"
-
-# Configure the ParaTime.
-RUN mkdir -p "$(dirname ${PARATIME})"
-ADD "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" "/paratime.orc"
-RUN unzip "paratime.orc" \
-	&& chmod a+x "runtime.elf"
-
-# Write VERSION information.
-RUN echo "${VERSION}" > /VERSION
-
-USER postgres
-RUN /etc/init.d/postgresql start \
-	&& psql --command "ALTER USER postgres WITH SUPERUSER PASSWORD 'postgres';"
+	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}" \
+	&& rm "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
+	&& rm -rf "oasis_core_${OASIS_CORE_VERSION}_linux_amd64" \
+	&& echo "" \
+	&& echo "Configure the ParaTime." \
+	&& mkdir -p "$(dirname ${PARATIME})" \
+    && wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
+    && unzip "paratime.orc" \
+    && chmod a+x "runtime.elf" \
+	&& rm "paratime.orc" \
+	&& echo "" \
+	&& echo "Configure oasis-cli." \
+	&& wget --quiet "https://github.com/oasisprotocol/cli/releases/download/v${OASIS_CLI_VERSION}/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
+    && tar -xvf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
+	&& mv "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64/oasis" / \
+	&& rm -rf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64/" \
+	&& rm -rf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
+	&& echo "" \
+	&& echo "Write VERSION information." \
+	&& echo "${VERSION}" > /VERSION
 
 # Web3 gateway http and ws ports.
 EXPOSE 8545/tcp

--- a/docker/emerald-dev/test.sh
+++ b/docker/emerald-dev/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Temporarily disabled. See https://github.com/oasisprotocol/oasis-web3-gateway/issues/471
+exit 0
+
+set -euo pipefail
+
+TAG=${TAG:-ghcr.io/oasisprotocol/emerald-dev:local}
+NAME="emerald-dev-test"
+
+cleanup() {
+	# Print standard output content.
+	docker logs "${NAME}" || true
+	# Stop the docker container.
+	docker stop "${NAME}" >/dev/null || true
+}
+
+trap cleanup INT TERM
+
+docker run -itd --rm -p8545:8545 --name "${NAME}" "${TAG}" -test-mnemonic >/dev/null
+
+# Check, if depositing tokens to test accounts worked.
+while true; do
+	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65", "latest"],"id":1}' http://localhost:8545 || true)
+	echo $OUT | grep -q 0x21e19e0c9bab2400000 && break
+	sleep 1
+done
+
+cleanup

--- a/docker/sapphire-dev/test.sh
+++ b/docker/sapphire-dev/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TAG=${TAG:-ghcr.io/oasisprotocol/sapphire-dev:local}
+NAME="sapphire-dev-test"
+
+cleanup() {
+	# Print standard output content.
+	docker logs "${NAME}" || true
+	# Stop the docker container.
+	docker stop "${NAME}" >/dev/null || true
+}
+
+trap cleanup INT TERM
+
+docker run -itd --rm -p8545:8545 --name "${NAME}" "${TAG}" -test-mnemonic >/dev/null
+
+# Check, if depositing tokens to test accounts worked.
+while true; do
+	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65", "latest"],"id":1}' http://localhost:8545 || true)
+	echo $OUT | grep -q 0x21e19e0c9bab2400000 && break
+	sleep 1
+done
+
+# Check, if public ephemeral key needed for c10l contracts exists.
+while true; do
+	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"oasis_callDataPublicKey","params":[],"id":2}' http://localhost:8545 || true)
+	echo $OUT | grep -q checksum && break
+	sleep 1
+done
+
+cleanup

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -169,16 +169,18 @@ func TestEth_GetBlockByNumberAndGetBlockByHash(t *testing.T) {
 	chainID, err := ec.ChainID(ctx)
 	require.NoError(t, err, "ec.ChainID")
 	blockGasLimits := map[uint64]uint64{
-		// Emerald Mainnet.
-		0xa516: 10_000_000,
+		// Emerald Localnet.
+		0xa514: 30_000_000,
 		// Emerald Testnet.
 		0xa515: 30_000_000,
+		// Emerald Mainnet.
+		0xa516: 10_000_000,
+		// Sapphire Localnet.
+		0x5afd: 30_000_000,
 		// Sapphire Testnet.
 		0x5aff: 30_000_000,
 		// Sapphire Mainnet.
 		0x5afe: 15_000_000,
-		// Sapphire Localnet.
-		0x5afd: 15_000_000,
 	}
 	require.EqualValues(t, blockGasLimits[chainID.Uint64()], blk1.GasLimit(), "expected block gas limit")
 

--- a/tests/rpc/tx_test.go
+++ b/tests/rpc/tx_test.go
@@ -229,7 +229,7 @@ func TestEth_GetCode(t *testing.T) {
 	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
 		require.EqualValues(t, uint64(103647), receipt.GasUsed, "expected contract creation gas used")
 	} else {
-		require.EqualValues(t, uint64(103630), receipt.GasUsed, "expected contract creation gas used")
+		require.EqualValues(t, uint64(103648), receipt.GasUsed, "expected contract creation gas used")
 	}
 	require.Equal(t, uint64(1), receipt.Status)
 
@@ -382,7 +382,7 @@ func TestERC20(t *testing.T) {
 	if tests.TestsConfig.Gateway.ExposeOasisRPCs {
 		require.EqualValues(t, uint64(52499), receipt.GasUsed, "ERC20-transfer expected gas use")
 	} else {
-		require.EqualValues(t, uint64(49699), receipt.GasUsed, "ERC20-transfer expected gas use")
+		require.EqualValues(t, uint64(52500), receipt.GasUsed, "ERC20-transfer expected gas use")
 	}
 
 	// Get balance of token receiver

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -62,6 +62,8 @@ if [[ ${SAPPHIRE_BACKEND-} == 'mock' ]]; then
   # Set beacon backend to 'debug mock'
   jq ".network.beacon.debug_mock_backend = true" "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
   mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
+  jq ".network.beacon.insecure_parameters.interval = 2" "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+  mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 fi
 
 # Whitelist compute node for key manager.


### PR DESCRIPTION
This PR:
- waits for the key manager to generate the ephemeral secret (the first possible epoch for this is 3)  and then transitions to that epoch so the ephemeral key can be used by dApps (this behavior was new in Oasis Core 23.x)
- sets the beacon interval to 2. This interval determines among how many KM nodes the KM will propose the new ephemeral key. The previous value was 50 meaning there is 1/50 chance KM proposing the ephemeral secret every block, the block time is 1 second. On the Mainnet/Testnet this number is computed by taking the epoch length into account, but since we use mock epochs in the Docker image, the beacon interval needs to be hardcoded.
- bumps ci-test to use the new sapphire-runtime 7.0.0-testnet and emerald-runtime 11.0.0-testnet
- uses the **localnet**  version of emerald-runtime in ci-test as well for consistency with sapphire
- adds a test to sapphire-dev and emerald-dev for `eth_getBalance` which checks if the testing account was funded
- **emerald-dev tests currently disabled due to #471**
- adds a test for sapphire-dev, if `oasis_callDataPublicKey` works
- builds Docker images and tests them on pull requests too now, not just when pushed to main