### PR TITLE
fix: emerald-dev initialization

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -48,7 +48,7 @@ jobs:
           load: true
 
       - name: Test
-        timeout-minutes: 5
+        timeout-minutes: 2
         working-directory: docker/${{ matrix.docker_image }}
         run: ./test.sh
 

--- a/docker/emerald-dev/Dockerfile
+++ b/docker/emerald-dev/Dockerfile
@@ -50,7 +50,7 @@ COPY tests/tools/* /
 
 # Configure oasis-node and oasis-net-runner.
 RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"  \
-    && tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
+	&& tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
 	&& mkdir -p "$(dirname ${OASIS_NODE})" "$(dirname ${OASIS_NET_RUNNER})" \
 	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE}" \
 	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}" \
@@ -59,14 +59,14 @@ RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/
 	&& echo "" \
 	&& echo "Configure the ParaTime." \
 	&& mkdir -p "$(dirname ${PARATIME})" \
-    && wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
-    && unzip "paratime.orc" \
-    && chmod a+x "runtime.elf" \
+	&& wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
+	&& unzip "paratime.orc" \
+	&& chmod a+x "runtime.elf" \
 	&& rm "paratime.orc" \
 	&& echo "" \
 	&& echo "Configure oasis-cli." \
 	&& wget --quiet "https://github.com/oasisprotocol/cli/releases/download/v${OASIS_CLI_VERSION}/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
-    && tar -xvf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
+	&& tar -xvf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
 	&& mv "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64/oasis" / \
 	&& rm -rf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64/" \
 	&& rm -rf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \

--- a/docker/emerald-dev/test.sh
+++ b/docker/emerald-dev/test.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Temporarily disabled. See https://github.com/oasisprotocol/oasis-web3-gateway/issues/471
-exit 0
-
 set -euo pipefail
 
 TAG=${TAG:-ghcr.io/oasisprotocol/emerald-dev:local}

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -45,8 +45,8 @@ fi
 if [[ ! -z "${OASIS_SINGLE_COMPUTE_NODE:-}" ]]; then
   jq "
     .compute_workers = [.compute_workers[0]] |
-    .runtimes[1].executor.group_size = 1 |
-    .runtimes[1].executor.group_backup_size = 0
+    .runtimes[${RT_IDX}].executor.group_size = 1 |
+    .runtimes[${RT_IDX}].executor.group_backup_size = 0
   " "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
   mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 fi

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Supported ENV Variables:
 # - OASIS_NODE: path to oasis-node binary
 # - OASIS_NET_RUNNER: path to oasis-net-runner binary
-# - SAPPHIRE_BACKEND: choose 'mock' backend (default), or use other behavior
+# - BEACON_BACKEND: choose 'mock' backend (default), or use other behavior
 # - PARATIME: path to ParaTime binary (inside .orc bundle)
 # - PARATIME_VERSION: version of the binary. e.g. 3.0.0
 # - OASIS_NODE_DATADIR: path to temporary oasis-node data dir e.g. /tmp/oasis-localnet
@@ -58,7 +58,7 @@ jq "
 " "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
-if [[ ${SAPPHIRE_BACKEND-} == 'mock' ]]; then
+if [[ ${BEACON_BACKEND-} == 'mock' ]]; then
   # Set beacon backend to 'debug mock'
   jq ".network.beacon.debug_mock_backend = true" "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
   mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"


### PR DESCRIPTION
This PR:
- fixes initialization of emerald-dev
- enables mock epochs for emerald-dev too to speed up dApp unit tests
- reduces the timeout for docker tests in CI to 2 minutes

Fixes #471