### PR TITLE
Reduce size of dev docker images

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -48,7 +48,7 @@ jobs:
           load: true
 
       - name: Test
-        timeout-minutes: 2
+        timeout-minutes: 3
         working-directory: docker/${{ matrix.docker_image }}
         run: ./test.sh
 

--- a/docker/common/localnet.yml
+++ b/docker/common/localnet.yml
@@ -2,7 +2,7 @@ runtime_id: "8000000000000000000000000000000000000000000000000000000000000000"
 node_address: "unix:/serverdir/node/net-runner/network/client-0/internal.sock"
 
 log:
-  level: debug
+  level: info
   format: json
 
 database:

--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script spins up local oasis stack by running the spinup-oasis-stack.sh,
 # starts the web3 gateway on top of it, and deposits to a test account on the
@@ -10,6 +10,10 @@
 # - OASIS_DEPOSIT: path to oasis-deposit binary
 # - BEACON_BACKEND: beacon epoch transition mode 'mock' (default) or 'default'
 # - OASIS_SINGLE_COMPUTE_NODE: (default: true) if non-empty only run a single compute node
+
+set -euo pipefail
+
+export OASIS_DOCKER_USE_TIMESTAMPS_IN_NOTICES=${OASIS_DOCKER_USE_TIMESTAMPS_IN_NOTICES:-no}
 
 export OASIS_SINGLE_COMPUTE_NODE=${OASIS_SINGLE_COMPUTE_NODE-1}
 OASIS_WEB3_GATEWAY_VERSION=$(${OASIS_WEB3_GATEWAY} -v | head -n1 | cut -d " " -f 3 | sed -r 's/^v//')
@@ -23,8 +27,6 @@ export BEACON_BACKEND=${BEACON_BACKEND:-mock}
 OASIS_NODE_SOCKET=${OASIS_NODE_DATADIR}/net-runner/network/client-0/internal.sock
 OASIS_KM_SOCKET=${OASIS_NODE_DATADIR}/net-runner/network/keymanager-0/internal.sock
 
-set -euo pipefail
-
 function cleanup {
 	kill -9 $OASIS_WEB3_GATEWAY_PID
 	kill -9 $OASIS_NODE_PID
@@ -32,25 +34,49 @@ function cleanup {
 
 trap cleanup INT TERM EXIT
 
-echo " * Starting oasis-net-runner with ${PARATIME_NAME}"
-/spinup-oasis-stack.sh 2>1 &>/var/log/spinup-oasis-stack.log &
+# If we have an interactive terminal, use colors.
+ISATTY="$([ -t 0 ] && echo yes)"
+if [[ "x${ISATTY}" == "xyes" ]]; then
+	GREEN="\e[32;1m"
+	YELLOW="\e[33;1m"
+	CYAN="\e[36;1m"
+	OFF="\e[0m"
+else
+	GREEN=""
+	YELLOW=""
+	CYAN=""
+	OFF=""
+fi
+
+if [[ "x${OASIS_DOCKER_USE_TIMESTAMPS_IN_NOTICES}" == "xyes" ]]; then
+function notice {
+	printf "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${OFF} $@"
+}
+else
+function notice {
+	printf "${CYAN} *${OFF} $@"
+}
+fi
+
+T_START="$(date +%s)"
+
+notice "Starting oasis-net-runner with ${CYAN}${PARATIME_NAME}${OFF}...\n"
+/spinup-oasis-stack.sh --log.level info 2>1 &>/var/log/spinup-oasis-stack.log &
 OASIS_NODE_PID=$!
 
-chown -R postgres:postgres /etc/postgresql /var/run/postgresql /var/log/postgresql /var/lib/postgresql/
-chown postgres:ssl-cert /etc/ssl/private/
-chown postgres:postgres /etc/ssl/private/ssl-cert-snakeoil.key
-chmod 600               /etc/ssl/private/ssl-cert-snakeoil.key
-/etc/init.d/postgresql start
+notice "Starting postgres...\n"
+su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres 2>1 &>/var/log/postgres.log
 
-echo " * Starting oasis-web3-gateway"
+notice "Waiting for Oasis node to start...\n"
 # Wait for oasis-node socket before starting web3 gateway.
-while ! [[ -S ${OASIS_NODE_SOCKET} ]]; do sleep 1; done
+while [[ ! -S ${OASIS_NODE_SOCKET} ]]; do sleep 1; done
 
+notice "Starting oasis-web3-gateway...\n"
 ${OASIS_WEB3_GATEWAY} --config ${OASIS_WEB3_GATEWAY_CONFIG_FILE} 2>1 &>/var/log/oasis-web3-gateway.log &
 OASIS_WEB3_GATEWAY_PID=$!
 
 # Wait for compute nodes before initiating deposit.
-echo -n " * Bootstrapping network (this might take a minute)"
+notice "Bootstrapping network (this might take a minute)"
 if [[ ${BEACON_BACKEND} == 'mock' ]]; then
 	echo -n .
 	${OASIS_NODE} debug control wait-nodes -n 2 -a unix:${OASIS_NODE_SOCKET}
@@ -68,18 +94,20 @@ if [[ ${BEACON_BACKEND} == 'mock' ]]; then
 	echo -n .
 	${OASIS_NODE} debug control set-epoch --epoch 2 -a unix:${OASIS_NODE_SOCKET}
 else
+	echo -n ...
 	${OASIS_NODE} debug control wait-ready -a unix:${OASIS_NODE_SOCKET}
 fi
 
 echo
-echo " * Populating accounts"
-echo
+notice "Populating accounts...\n\n"
 ${OASIS_DEPOSIT} -sock unix:${OASIS_NODE_SOCKET} "$@"
 
+T_END="$(date +%s)"
+
 echo
-echo "WARNING: The chain is running in ephemeral mode. State will be lost after restart!"
-echo
-echo "Listening on http://localhost:8545 and ws://localhost:8546"
+printf "${YELLOW}WARNING: The chain is running in ephemeral mode. State will be lost after restart!${OFF}\n\n"
+notice "Listening on ${CYAN}http://localhost:8545${OFF} and ${CYAN}ws://localhost:8546${OFF}\n"
+notice "Container start-up took ${CYAN}$((T_END-T_START))${OFF} seconds.\n"
 
 if [[ ${BEACON_BACKEND} == 'mock' ]]; then
 	# Run background task to switch epochs every 5 minutes

--- a/docker/emerald-dev/Dockerfile
+++ b/docker/emerald-dev/Dockerfile
@@ -2,10 +2,12 @@
 FROM golang:1.21 AS oasis-web3-gateway
 
 COPY . /go/oasis-web3-gateway
-RUN cd oasis-web3-gateway && make build
+RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/common/oasis-deposit/oasis-deposit
 
 # Build emerald-dev
-FROM ubuntu:22.04
+FROM postgres:16-alpine
+RUN apk add --no-cache bash gcompat libseccomp jq binutils \
+	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
 
 # Docker-specific variables
 ENV OASIS_CORE_VERSION=23.0.6
@@ -25,21 +27,6 @@ ENV PARATIME=/runtime.elf
 ENV KEYMANAGER_BINARY=""
 
 ARG VERSION
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Install Postgresql and other tools packaged by Ubuntu.
-RUN apt update -qq \
-	&& apt dist-upgrade -qq -y \
-	&& apt install jq postgresql unzip ca-certificates wget -y \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& echo "" \
-	&& echo "Initialize PostgreSQL database, permissions need to be setup" \
-	&& chown -R postgres:postgres /etc/postgresql /var/run/postgresql /var/log/postgresql /var/lib/postgresql/ \
-	&& chown postgres:ssl-cert /etc/ssl/private/ \
-	&& chown postgres:postgres /etc/ssl/private/ssl-cert-snakeoil.key \
-	&& chmod 600               /etc/ssl/private/ssl-cert-snakeoil.key  \
-	&& /etc/init.d/postgresql start \
-	&& su -c "psql --command \"ALTER USER postgres WITH SUPERUSER PASSWORD 'postgres';\"" postgres
 
 # oasis-web3-gateway binary, config, spinup-* scripts and staking_genesis.json.
 COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY}
@@ -72,7 +59,8 @@ RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/
 	&& rm -rf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
 	&& echo "" \
 	&& echo "Write VERSION information." \
-	&& echo "${VERSION}" > /VERSION
+	&& echo "${VERSION}" > /VERSION \
+	&& strip -S -x /oasis-net-runner /oasis-node /oasis
 
 # Web3 gateway http and ws ports.
 EXPOSE 8545/tcp

--- a/docker/emerald-dev/test.sh
+++ b/docker/emerald-dev/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/docker/sapphire-dev/Dockerfile
+++ b/docker/sapphire-dev/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.21 AS oasis-web3-gateway
 
 COPY . /go/oasis-web3-gateway
-RUN cd oasis-web3-gateway && make build
+RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/common/oasis-deposit/oasis-deposit
 
 # Build simple-keymanager
 FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-23.0.x AS oasis-core-dev
@@ -11,26 +11,12 @@ ENV OASIS_UNSAFE_SKIP_KM_POLICY=1
 
 RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch stable/23.0.x --depth 1 \
 	&& cd oasis-core/tests/runtimes/simple-keymanager \
-	&& cargo build
+	&& cargo build --release
 
 # Build sapphire-dev
-FROM ubuntu:22.04
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Install Postgresql and other tools packaged by Ubuntu.
-RUN apt update -qq \
-	&& apt dist-upgrade -qq -y \
-	&& apt install jq postgresql unzip ca-certificates wget -y \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& echo "" \
-	&& echo "Initialize PostgreSQL database, permissions need to be setup" \
-	&& chown -R postgres:postgres /etc/postgresql /var/run/postgresql /var/log/postgresql /var/lib/postgresql/ \
-	&& chown postgres:ssl-cert /etc/ssl/private/ \
-	&& chown postgres:postgres /etc/ssl/private/ssl-cert-snakeoil.key \
-	&& chmod 600               /etc/ssl/private/ssl-cert-snakeoil.key  \
-	&& /etc/init.d/postgresql start \
-	&& su -c "psql --command \"ALTER USER postgres WITH SUPERUSER PASSWORD 'postgres';\"" postgres
+FROM postgres:16-alpine
+RUN apk add --no-cache bash gcompat libseccomp jq binutils \
+	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
 
 # Docker-specific variables
 ENV OASIS_CORE_VERSION=23.0.6
@@ -55,7 +41,7 @@ ENV OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
 ARG VERSION
 
 # simple-keymanager
-COPY --from=oasis-core-dev /oasis-core/target/debug/simple-keymanager ${KEYMANAGER_BINARY}
+COPY --from=oasis-core-dev /oasis-core/target/release/simple-keymanager ${KEYMANAGER_BINARY}
 
 # oasis-web3-gateway binary, config, spinup-* scripts and staking_genesis.json.
 COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY}
@@ -88,7 +74,10 @@ RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/
 	&& rm -rf "/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz" \
 	&& echo "" \
 	&& echo "Write VERSION information." \
-	&& echo "${VERSION}" > /VERSION
+	&& echo "${VERSION}" > /VERSION \
+	&& strip -S -x /oasis-net-runner /oasis-node /oasis /simple-keymanager \
+	&& echo "" \
+	&& ls -l /
 
 # Web3 gateway http and ws ports.
 EXPOSE 8545/tcp

--- a/docker/sapphire-dev/test.sh
+++ b/docker/sapphire-dev/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -87,4 +87,4 @@ jq ".runtimes[${RT_IDX}].txn_scheduler.batch_flush_timeout=1000000000" "$FIXTURE
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
 # Run oasis-node.
-${OASIS_NET_RUNNER} --fixture.file "$FIXTURE_FILE" --basedir "${OASIS_NODE_DATADIR}" --basedir.no_temp_dir
+${OASIS_NET_RUNNER} --fixture.file "$FIXTURE_FILE" --basedir "${OASIS_NODE_DATADIR}" --basedir.no_temp_dir $@


### PR DESCRIPTION
The size of the development docker images was reduced.
`sapphire-dev` was reduced from 835MB to 430MB.
`emerald-dev` was reduced from 683MB to 419MB.
