### PR TITLE
feat: implement eth_feeHistory endpoint

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -243,6 +243,8 @@ type GasConfig struct {
 	WindowSize uint64 `koanf:"window_size"`
 	// ComputedPriceMargin is the gas price to add to the computed gas price.
 	ComputedPriceMargin uint64 `koanf:"computed_price_margin"`
+	// FeeHistorySize is the number of recent blocks to store for the fee history query.
+	FeeHistorySize uint64 `koanf:"fee_history_size"`
 }
 
 // Validate validates the gas configuration.

--- a/gas/backend_test.go
+++ b/gas/backend_test.go
@@ -126,6 +126,11 @@ func TestGasPriceOracle(t *testing.T) {
 	// Default gas price should be returned by the oracle.
 	require.EqualValues(defaultGasPrice.ToBigInt(), gasPriceOracle.GasPrice(), "oracle should return default gas price")
 
+	fh := gasPriceOracle.FeeHistory(10, 10, []float64{0.25, 0.5})
+	require.EqualValues(0, fh.OldestBlock.ToInt().Int64(), "fee history should be empty")
+	require.Empty(0, fh.GasUsedRatio, "fee history should be empty")
+	require.Empty(0, fh.Reward, "fee history should be empty")
+
 	// Emit a non-full block.
 	emitBlock(&emitter, false, nil)
 
@@ -136,7 +141,7 @@ func TestGasPriceOracle(t *testing.T) {
 	emitBlock(&emitter, true, quantity.NewFromUint64(1_000_000_000_000)) // 1000 gwei.
 
 	// 1001 gwei should be returned.
-	require.EqualValues(big.NewInt(1_001_000_000_000), gasPriceOracle.GasPrice(), "oracle should return correct gas price")
+	require.EqualValues(big.NewInt(1_001_000_000_000), gasPriceOracle.GasPrice().ToInt(), "oracle should return correct gas price")
 
 	// Emit a non-full block.
 	emitBlock(&emitter, false, nil)

--- a/gas/fee_history.go
+++ b/gas/fee_history.go
@@ -1,0 +1,181 @@
+package gas
+
+import (
+	"math/big"
+	"slices"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	ethMath "github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/oasisprotocol/oasis-web3-gateway/db/model"
+)
+
+// defaultFeeHistorySize is the default number of recent blocks to store for the fee history query.
+const defaultFeeHistorySize uint64 = 20
+
+// FeeHistoryResult is the result of a fee history query.
+type FeeHistoryResult struct {
+	OldestBlock  *hexutil.Big     `json:"oldestBlock"`
+	Reward       [][]*hexutil.Big `json:"reward,omitempty"`
+	BaseFee      []*hexutil.Big   `json:"baseFeePerGas,omitempty"`
+	GasUsedRatio []float64        `json:"gasUsedRatio"`
+}
+
+type txGasAndReward struct {
+	gasUsed uint64
+	reward  *hexutil.Big
+}
+
+type feeHistoryBlockData struct {
+	height       uint64
+	baseFee      *hexutil.Big
+	gasUsedRatio float64
+	gasUsed      uint64
+
+	// Sorted list of transaction by reward. This is used to
+	// compute the queried percentiles in the fee history query.
+	sortedTxs []*txGasAndReward
+}
+
+// rewards computes the queried reward percentiles for the given block data.
+func (d *feeHistoryBlockData) rewards(percentiles []float64) []*hexutil.Big {
+	rewards := make([]*hexutil.Big, len(percentiles))
+
+	// No percentiles requested.
+	if len(percentiles) == 0 {
+		return rewards
+	}
+
+	// No transactions in the block.
+	if len(d.sortedTxs) == 0 {
+		for i := range rewards {
+			rewards[i] = (*hexutil.Big)(common.Big0)
+		}
+		return rewards
+	}
+
+	// Compute the requested percentiles.
+	var txIndex int
+	sumGasUsed := d.sortedTxs[0].gasUsed
+	for i, p := range percentiles {
+		thresholdGasUsed := uint64(float64(d.gasUsed) * p / 100)
+		for sumGasUsed < thresholdGasUsed && txIndex < len(d.sortedTxs)-1 {
+			txIndex++
+			sumGasUsed += d.sortedTxs[txIndex].gasUsed
+		}
+		rewards[i] = d.sortedTxs[txIndex].reward
+	}
+
+	return rewards
+}
+
+// Implements Backend.
+func (g *gasPriceOracle) FeeHistory(blockCount uint64, lastBlock rpc.BlockNumber, percentiles []float64) *FeeHistoryResult {
+	g.feeHistoryLock.RLock()
+	defer g.feeHistoryLock.RUnlock()
+
+	// No history available.
+	if len(g.feeHistoryData) == 0 {
+		return &FeeHistoryResult{OldestBlock: (*hexutil.Big)(common.Big0)}
+	}
+
+	// Find the latest block index.
+	var lastBlockIdx int
+	switch lastBlock {
+	case rpc.PendingBlockNumber, rpc.LatestBlockNumber, rpc.FinalizedBlockNumber, rpc.SafeBlockNumber:
+		// Latest available block.
+		lastBlockIdx = len(g.feeHistoryData) - 1
+	case rpc.EarliestBlockNumber:
+		// Doesn't make sense to start at earliest block.
+		return &FeeHistoryResult{OldestBlock: (*hexutil.Big)(common.Big0)}
+	default:
+		// Check if the requested block number is available.
+		var found bool
+		for i, d := range g.feeHistoryData {
+			if d.height == uint64(lastBlock) {
+				lastBlockIdx = i
+				found = true
+				break
+			}
+		}
+		// Data for requested block number not available.
+		if !found {
+			return &FeeHistoryResult{OldestBlock: (*hexutil.Big)(common.Big0)}
+		}
+	}
+
+	// Find the oldest block index.
+	var oldestBlockIdx int
+	if blockCount > uint64(lastBlockIdx) {
+		// Not enough blocks available, return all available blocks.
+		oldestBlockIdx = 0
+	} else {
+		oldestBlockIdx = lastBlockIdx + 1 - int(blockCount)
+	}
+
+	// Return the requested fee history.
+	result := &FeeHistoryResult{
+		OldestBlock:  (*hexutil.Big)(big.NewInt(int64(g.feeHistoryData[oldestBlockIdx].height))),
+		Reward:       make([][]*hexutil.Big, lastBlockIdx-oldestBlockIdx+1),
+		BaseFee:      make([]*hexutil.Big, lastBlockIdx-oldestBlockIdx+1),
+		GasUsedRatio: make([]float64, lastBlockIdx-oldestBlockIdx+1),
+	}
+	for i := oldestBlockIdx; i <= lastBlockIdx; i++ {
+		result.Reward[i-oldestBlockIdx] = g.feeHistoryData[i].rewards(percentiles)
+		result.BaseFee[i-oldestBlockIdx] = g.feeHistoryData[i].baseFee
+		result.GasUsedRatio[i-oldestBlockIdx] = g.feeHistoryData[i].gasUsedRatio
+	}
+
+	return result
+}
+
+func (g *gasPriceOracle) trackFeeHistory(block *model.Block, txs []*model.Transaction, receipts []*model.Receipt) {
+	// TODO: could populate old blocks on first received block (if available).
+
+	d := &feeHistoryBlockData{
+		height:       block.Round,
+		gasUsed:      block.Header.GasUsed,
+		gasUsedRatio: float64(block.Header.GasUsed) / float64(block.Header.GasLimit),
+		sortedTxs:    make([]*txGasAndReward, len(receipts)),
+	}
+
+	// Base fee.
+	var baseFee big.Int
+	if err := baseFee.UnmarshalText([]byte(block.Header.BaseFee)); err != nil {
+		g.Logger.Error("unmarshal base fee", "base_fee", block.Header.BaseFee, "block", block, "err", err)
+		return
+	}
+	d.baseFee = (*hexutil.Big)(&baseFee)
+
+	// Transactions.
+	for i, tx := range txs {
+		var tipGas, feeCap big.Int
+		if err := feeCap.UnmarshalText([]byte(tx.GasFeeCap)); err != nil {
+			g.Logger.Error("unmarshal gas fee cap", "fee_cap", tx.GasFeeCap, "block", block, "tx", tx, "err", err)
+			return
+		}
+		if err := tipGas.UnmarshalText([]byte(tx.GasTipCap)); err != nil {
+			g.Logger.Error("unmarshal gas tip cap", "tip_cap", tx.GasTipCap, "block", block, "tx", tx, "err", err)
+			return
+		}
+
+		d.sortedTxs[i] = &txGasAndReward{
+			gasUsed: receipts[i].GasUsed,
+			reward:  (*hexutil.Big)(ethMath.BigMin(&tipGas, &feeCap)),
+		}
+	}
+	slices.SortStableFunc(d.sortedTxs, func(a, b *txGasAndReward) int {
+		return a.reward.ToInt().Cmp(b.reward.ToInt())
+	})
+
+	// Add new data to the history.
+	g.feeHistoryLock.Lock()
+	defer g.feeHistoryLock.Unlock()
+	// Delete oldest entry if we are at capacity.
+	if len(g.feeHistoryData) == int(g.feeHistorySize) {
+		g.feeHistoryData = g.feeHistoryData[1:]
+	}
+	g.feeHistoryData = append(g.feeHistoryData, d)
+}

--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -84,7 +84,7 @@ type Backend interface {
 		ctx context.Context,
 		oasisBlock *block.Block,
 		txResults []*client.TransactionWithResults,
-		blockGasLimit uint64,
+		coreParameters *core.Parameters,
 		rtInfo *core.RuntimeInfoResponse,
 	) error
 
@@ -141,10 +141,10 @@ func (ib *indexBackend) SetObserver(ob BackendObserver) {
 }
 
 // Index indexes oasis block.
-func (ib *indexBackend) Index(ctx context.Context, oasisBlock *block.Block, txResults []*client.TransactionWithResults, blockGasLimit uint64, rtInfo *core.RuntimeInfoResponse) error {
+func (ib *indexBackend) Index(ctx context.Context, oasisBlock *block.Block, txResults []*client.TransactionWithResults, coreParameters *core.Parameters, rtInfo *core.RuntimeInfoResponse) error {
 	round := oasisBlock.Header.Round
 
-	err := ib.StoreBlockData(ctx, oasisBlock, txResults, blockGasLimit)
+	err := ib.StoreBlockData(ctx, oasisBlock, txResults, coreParameters)
 	if err != nil {
 		ib.logger.Error("generateEthBlock failed", "err", err)
 		return err

--- a/indexer/backend_cache.go
+++ b/indexer/backend_cache.go
@@ -169,10 +169,10 @@ func (cb *cachingBackend) Index(
 	ctx context.Context,
 	oasisBlock *block.Block,
 	txResults []*client.TransactionWithResults,
-	blockGasLimit uint64,
+	coreParameters *core.Parameters,
 	rtInfo *core.RuntimeInfoResponse,
 ) error {
-	return cb.inner.Index(ctx, oasisBlock, txResults, blockGasLimit, rtInfo)
+	return cb.inner.Index(ctx, oasisBlock, txResults, coreParameters, rtInfo)
 }
 
 func (cb *cachingBackend) Prune(

--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
@@ -42,6 +43,7 @@ var (
 	ErrMalformedTransaction = errors.New("malformed transaction")
 	ErrMalformedBlockNumber = errors.New("malformed blocknumber")
 	ErrInvalidRequest       = errors.New("invalid request")
+	ErrInvalidPercentile    = errors.New("invalid reward percentile")
 
 	// estimateGasSigSpec is a dummy signature spec used by the estimate gas method, as
 	// otherwise transactions without signature would be underestimated.
@@ -62,6 +64,8 @@ type API interface {
 	ChainId() (*hexutil.Big, error)
 	// GasPrice returns a suggestion for a gas price for legacy transactions.
 	GasPrice(ctx context.Context) (*hexutil.Big, error)
+	// FeeHistory returns the transaction base fee per gas and effective priority fee per gas for the requested/supported block range.
+	FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64, lastBlock ethrpc.BlockNumber, rewardPercentiles []float64) (*gas.FeeHistoryResult, error)
 	// GetBlockTransactionCountByHash returns the number of transactions in the block identified by hash.
 	GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (hexutil.Uint, error)
 	// GetTransactionCount returns the number of transactions the given address has sent for the given block number.
@@ -288,6 +292,29 @@ func (api *publicAPI) GasPrice(_ context.Context) (*hexutil.Big, error) {
 	logger.Debug("request")
 
 	return api.gasPriceOracle.GasPrice(), nil
+}
+
+func (api *publicAPI) FeeHistory(_ context.Context, blockCount math.HexOrDecimal64, lastBlock ethrpc.BlockNumber, rewardPercentiles []float64) (*gas.FeeHistoryResult, error) {
+	logger := api.Logger.With("method", "eth_feeHistory", "block_count", blockCount, "last_block", lastBlock, "reward_percentiles", rewardPercentiles)
+	logger.Debug("request")
+
+	// Validate blockCount.
+	if blockCount < 1 {
+		// Returning with no data and no error means there are no retrievable blocks.
+		return &gas.FeeHistoryResult{OldestBlock: (*hexutil.Big)(common.Big0)}, nil
+	}
+
+	// Validate reward percentiles.
+	for i, p := range rewardPercentiles {
+		if p < 0 || p > 100 {
+			return nil, fmt.Errorf("%w: %f", ErrInvalidPercentile, p)
+		}
+		if i > 0 && p < rewardPercentiles[i-1] {
+			return nil, fmt.Errorf("%w: #%d:%f > #%d:%f", ErrInvalidPercentile, i-1, rewardPercentiles[i-1], i, p)
+		}
+	}
+
+	return api.gasPriceOracle.FeeHistory(uint64(blockCount), lastBlock, rewardPercentiles), nil
 }
 
 func (api *publicAPI) GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (hexutil.Uint, error) {

--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -64,6 +64,8 @@ type API interface {
 	ChainId() (*hexutil.Big, error)
 	// GasPrice returns a suggestion for a gas price for legacy transactions.
 	GasPrice(ctx context.Context) (*hexutil.Big, error)
+	// MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions
+	MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error)
 	// FeeHistory returns the transaction base fee per gas and effective priority fee per gas for the requested/supported block range.
 	FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64, lastBlock ethrpc.BlockNumber, rewardPercentiles []float64) (*gas.FeeHistoryResult, error)
 	// GetBlockTransactionCountByHash returns the number of transactions in the block identified by hash.
@@ -289,6 +291,13 @@ func (api *publicAPI) ChainId() (*hexutil.Big, error) {
 
 func (api *publicAPI) GasPrice(_ context.Context) (*hexutil.Big, error) {
 	logger := api.Logger.With("method", "eth_gasPrice")
+	logger.Debug("request")
+
+	return api.gasPriceOracle.GasPrice(), nil
+}
+
+func (api *publicAPI) MaxPriorityFeePerGas(_ context.Context) (*hexutil.Big, error) {
+	logger := api.Logger.With("method", "eth_maxPriorityFeePerGas")
 	logger.Debug("request")
 
 	return api.gasPriceOracle.GasPrice(), nil

--- a/rpc/eth/metrics/api.go
+++ b/rpc/eth/metrics/api.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-core/go/common/logging"
 
+	"github.com/oasisprotocol/oasis-web3-gateway/gas"
 	"github.com/oasisprotocol/oasis-web3-gateway/indexer"
 	"github.com/oasisprotocol/oasis-web3-gateway/rpc/eth"
 	"github.com/oasisprotocol/oasis-web3-gateway/rpc/metrics"
@@ -143,6 +145,15 @@ func (m *metricsWrapper) GasPrice(ctx context.Context) (res *hexutil.Big, err er
 	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
 
 	res, err = m.api.GasPrice(ctx)
+	return
+}
+
+// FeeHistory implements eth.API.
+func (m *metricsWrapper) FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64, lastBlock ethrpc.BlockNumber, rewardPercentiles []float64) (res *gas.FeeHistoryResult, err error) {
+	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_feeHistory")
+	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
+
+	res, err = m.api.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
 	return
 }
 

--- a/rpc/eth/metrics/api.go
+++ b/rpc/eth/metrics/api.go
@@ -148,6 +148,15 @@ func (m *metricsWrapper) GasPrice(ctx context.Context) (res *hexutil.Big, err er
 	return
 }
 
+// MaxPriorityFeePerGas implements eth.API.
+func (m *metricsWrapper) MaxPriorityFeePerGas(ctx context.Context) (res *hexutil.Big, err error) {
+	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_maxPriorityFeePerGas")
+	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
+
+	res, err = m.api.MaxPriorityFeePerGas(ctx)
+	return
+}
+
 // FeeHistory implements eth.API.
 func (m *metricsWrapper) FeeHistory(ctx context.Context, blockCount math.HexOrDecimal64, lastBlock ethrpc.BlockNumber, rewardPercentiles []float64) (res *gas.FeeHistoryResult, err error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_feeHistory")

--- a/rpc/metrics/metrics.go
+++ b/rpc/metrics/metrics.go
@@ -24,7 +24,7 @@ func GetAPIMethodMetrics(method string) (prometheus.Counter, prometheus.Counter,
 
 // InstrumentCaller instruments the caller method.
 //
-// Use InstrumentCaller is usually used the following way:
+// The InstrumentCaller should be used the following way:
 //
 //	   func InstrumentMe() (err error) {
 //		  r, s, f, i, d := metrics.GetAPIMethodMetrics("method")

--- a/rpc/utils/utils.go
+++ b/rpc/utils/utils.go
@@ -145,10 +145,10 @@ func DB2EthLogs(dbLogs []*model.Log) []*ethtypes.Log {
 
 // DB2EthHeader converts block in db to ethereum header.
 func DB2EthHeader(block *model.Block) *ethtypes.Header {
-	v1 := big.NewInt(0)
-	diff, _ := v1.SetString(block.Header.Difficulty, 10)
+	diff, _ := new(big.Int).SetString(block.Header.Difficulty, 10)
 	noPrefix := block.Header.Bloom[2 : len(block.Header.Bloom)-1]
 	bloomData, _ := hex.DecodeString(noPrefix)
+	baseFee, _ := new(big.Int).SetString(block.Header.BaseFee, 10)
 	res := &ethtypes.Header{
 		ParentHash:  common.HexToHash(block.Header.ParentHash),
 		UncleHash:   common.HexToHash(block.Header.UncleHash),
@@ -165,8 +165,7 @@ func DB2EthHeader(block *model.Block) *ethtypes.Header {
 		Extra:       []byte(block.Header.Extra),
 		MixDigest:   common.HexToHash(block.Header.MixDigest),
 		Nonce:       ethtypes.EncodeNonce(block.Header.Nonce),
-		// BaseFee was added by EIP-1559 and is ignored in legacy headers.
-		BaseFee: big.NewInt(0),
+		BaseFee:     baseFee,
 	}
 
 	return res

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -146,6 +146,15 @@ func TestEth_GasPrice(t *testing.T) {
 	t.Logf("gas price: %v", price)
 }
 
+func TestEth_MaxPriorityFeePerGas(t *testing.T) {
+	ec := localClient(t, false)
+
+	price, err := ec.SuggestGasTipCap(context.Background())
+	require.Nil(t, err, "get maxPriorityFeePerGas")
+
+	t.Logf("max priority fee per gas: %v", price)
+}
+
 func TestEth_FeeHistory(t *testing.T) {
 	ec := localClient(t, false)
 

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -146,6 +146,55 @@ func TestEth_GasPrice(t *testing.T) {
 	t.Logf("gas price: %v", price)
 }
 
+func TestEth_FeeHistory(t *testing.T) {
+	ec := localClient(t, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)
+	defer cancel()
+
+	// Submit some test transactions.
+	for i := 0; i < 5; i++ {
+		receipt := submitTestTransaction(ctx, t)
+		require.EqualValues(t, 1, receipt.Status)
+		require.NotNil(t, receipt)
+	}
+
+	// Base fee history test.
+	feeHistory, err := ec.FeeHistory(context.Background(), 10, nil, []float64{25, 50, 75, 100})
+	require.NoError(t, err, "get fee history")
+
+	t.Logf("fee history: %v", feeHistory)
+	require.Len(t, feeHistory.BaseFee, 10, "fee history base fee should have 10 elements")
+	for _, fee := range feeHistory.BaseFee {
+		require.Greater(t, fee.Int64(), int64(0), "base fee should be greater than 0")
+	}
+	require.Len(t, feeHistory.Reward, 10, "fee history reward should have 10 elements")
+
+	// More cases.
+	for _, tc := range []struct {
+		name        string
+		blockCount  uint64
+		lastBlock   *big.Int
+		percentiles []float64
+		expectErr   bool
+	}{
+		{name: "Query with no reward percentiles", blockCount: 5, lastBlock: nil, percentiles: nil, expectErr: false},
+		{name: "Query specific block range", blockCount: 3, lastBlock: big.NewInt(5), percentiles: []float64{50}, expectErr: false},
+		{name: "Query specific block range (large)", blockCount: 3, lastBlock: big.NewInt(100000), percentiles: []float64{50}, expectErr: false},
+		{name: "Query with zero block count (empty response)", blockCount: 0, lastBlock: nil, percentiles: []float64{50}, expectErr: false},
+		{name: "Query large block count", blockCount: 10_000, lastBlock: big.NewInt(11_000), percentiles: []float64{50}, expectErr: false},
+		{name: "Invalid percentile", blockCount: 5, lastBlock: nil, percentiles: []float64{150}, expectErr: true}, // Invalid percentile > 100
+	} {
+		_, err := ec.FeeHistory(ctx, tc.blockCount, tc.lastBlock, tc.percentiles)
+		switch tc.expectErr {
+		case true:
+			require.Error(t, err, tc.name)
+		default:
+			require.NoError(t, err, tc.name)
+		}
+	}
+}
+
 // TestEth_SendRawTransaction post eth raw transaction with ethclient from go-ethereum.
 func TestEth_SendRawTransaction(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), OasisBlockTimeout)


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/oasis-web3-gateway/issues/501

Implements eth_feeHistory endpoint. The query supports returning the history for the maximum last 20 (configurable) blocks (this arbitrarily set limit is allowed as per spec: [Requested range of blocks. Clients will return less than the requested range if not all blocks are available.](https://ethereum.github.io/execution-apis/api-documentation/))

To avoid fetching multiple blocks, transactions, and receipts from DB on every fee_history query (which can be expensive) the fee_history for last 20 (configurable) blocks is continuously pre-computed in the gas oracle (only the percentiles are computed on the fly).

TODO:
- [x] test