### PR TITLE
docker: Rename emerald and sapphire -dev to -localnet

### DIFF
--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,4 +1,4 @@
-name: docker-dev
+name: docker-localnet
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
   docker:
     strategy:
       matrix:
-        docker_image: [emerald-dev, sapphire-dev]
+        docker_image: [emerald-localnet, sapphire-localnet]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,13 @@ lint: $(lint-targets)
 release-build:
 	@goreleaser release --rm-dist
 
-docker: docker-emerald-dev docker-sapphire-dev
+docker: docker-emerald-localnet docker-sapphire-localnet
 
-docker-emerald-dev:
-	@docker build -t ghcr.io/oasisprotocol/emerald-dev:local --build-arg VERSION=local -f docker/emerald-dev/Dockerfile .
+docker-emerald-localnet:
+	@docker build -t ghcr.io/oasisprotocol/emerald-localnet:local --build-arg VERSION=local -f docker/emerald-localnet/Dockerfile .
 
-docker-sapphire-dev:
-	@docker build -t ghcr.io/oasisprotocol/sapphire-dev:local --build-arg VERSION=local -f docker/sapphire-dev/Dockerfile .
+docker-sapphire-localnet:
+	@docker build -t ghcr.io/oasisprotocol/sapphire-localnet:local --build-arg VERSION=local -f docker/sapphire-localnet/Dockerfile .
 
 
 # List of targets that are not actual files.

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,8 +10,8 @@ set up localnet for developing dApps running on Emerald or Sapphire:
 
 ## Prebuilt images
 
-Oasis provides prebuilt `emerald-dev` and `sapphire-dev` docker images. `latest`
-versions are based on:
+Oasis provides prebuilt `emerald-localnet` and `sapphire-localnet` docker
+images. `latest` versions are based on:
 - `stable` branch of `oasis-core`,
 - `master` branch of `oasis-sdk`,
 - `main` branch of `oasis-web3-gateway` repository.
@@ -19,8 +19,8 @@ versions are based on:
 To use the precompiled images, run:
 
 ```sh
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/emerald-dev # Emerald
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev # Sapphire
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/emerald-localnet # Emerald
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet # Sapphire
 ```
 
 ## Build image locally
@@ -35,8 +35,8 @@ make docker
 To run the compiled image type:
 
 ```sh
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/emerald-dev:local
-docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-dev:local
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/emerald-localnet:local
+docker run -it -p8545:8545 -p8546:8546 ghcr.io/oasisprotocol/sapphire-localnet:local
 ```
 
 ## Usage

--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -112,7 +112,7 @@ T_END="$(date +%s)"
 
 echo
 printf "${YELLOW}WARNING: The chain is running in ephemeral mode. State will be lost after restart!${OFF}\n\n"
-notice "Listening on ${CYAN}http://localhost:8545${OFF} and ${CYAN}ws://localhost:8546${OFF}\n"
+notice "Listening on ${CYAN}http://localhost:8545${OFF} and ${CYAN}ws://localhost:8546${OFF}. Chain ID: ${GATEWAY__CHAIN_ID}\n"
 notice "Container start-up took ${CYAN}$((T_END-T_START))${OFF} seconds.\n"
 
 if [[ ${BEACON_BACKEND} == 'mock' ]]; then

--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -19,7 +19,7 @@ export OASIS_SINGLE_COMPUTE_NODE=${OASIS_SINGLE_COMPUTE_NODE-1}
 OASIS_WEB3_GATEWAY_VERSION=$(${OASIS_WEB3_GATEWAY} -v | head -n1 | cut -d " " -f 3 | sed -r 's/^v//')
 OASIS_CORE_VERSION=$(${OASIS_NODE} -v | head -n1 | cut -d " " -f 3 | sed -r 's/^v//')
 VERSION=$(cat /VERSION)
-echo "${PARATIME_NAME}-dev ${VERSION} (oasis-core: ${OASIS_CORE_VERSION}, ${PARATIME_NAME}-paratime: ${PARATIME_VERSION}, oasis-web3-gateway: ${OASIS_WEB3_GATEWAY_VERSION})"
+echo "${PARATIME_NAME}-localnet ${VERSION} (oasis-core: ${OASIS_CORE_VERSION}, ${PARATIME_NAME}-paratime: ${PARATIME_VERSION}, oasis-web3-gateway: ${OASIS_WEB3_GATEWAY_VERSION})"
 echo
 
 export BEACON_BACKEND=${BEACON_BACKEND:-mock}

--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.21 AS oasis-web3-gateway
 COPY . /go/oasis-web3-gateway
 RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/common/oasis-deposit/oasis-deposit
 
-# Build emerald-dev
+# Build emerald-localnet
 FROM postgres:16-alpine
 RUN apk add --no-cache bash gcompat libseccomp jq binutils \
 	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres

--- a/docker/emerald-localnet/test.sh
+++ b/docker/emerald-localnet/test.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-TAG=${TAG:-ghcr.io/oasisprotocol/sapphire-dev:local}
-NAME="sapphire-dev-test"
+TAG=${TAG:-ghcr.io/oasisprotocol/emerald-localnet:local}
+NAME="emerald-localnet-test"
 
 cleanup() {
 	# Print standard output content.
@@ -20,13 +20,6 @@ docker run -itd --rm -p8545:8545 --name "${NAME}" "${TAG}" -test-mnemonic >/dev/
 while true; do
 	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65", "latest"],"id":1}' http://localhost:8545 || true)
 	echo $OUT | grep -q 0x21e19e0c9bab2400000 && break
-	sleep 1
-done
-
-# Check, if public ephemeral key needed for c10l contracts exists.
-while true; do
-	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"oasis_callDataPublicKey","params":[],"id":2}' http://localhost:8545 || true)
-	echo $OUT | grep -q checksum && break
 	sleep 1
 done
 

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch stable/23
 	&& cd cli \
 	&& make CGO_ENABLED=0
 
-# Build sapphire-dev
+# Build sapphire-localnet
 FROM postgres:16-alpine
 RUN apk add --no-cache bash gcompat libseccomp jq binutils \
 	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres

--- a/docker/sapphire-localnet/test.sh
+++ b/docker/sapphire-localnet/test.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-TAG=${TAG:-ghcr.io/oasisprotocol/emerald-dev:local}
-NAME="emerald-dev-test"
+TAG=${TAG:-ghcr.io/oasisprotocol/sapphire-localnet:local}
+NAME="sapphire-localnet-test"
 
 cleanup() {
 	# Print standard output content.
@@ -20,6 +20,13 @@ docker run -itd --rm -p8545:8545 --name "${NAME}" "${TAG}" -test-mnemonic >/dev/
 while true; do
 	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65", "latest"],"id":1}' http://localhost:8545 || true)
 	echo $OUT | grep -q 0x21e19e0c9bab2400000 && break
+	sleep 1
+done
+
+# Check, if public ephemeral key needed for c10l contracts exists.
+while true; do
+	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"oasis_callDataPublicKey","params":[],"id":2}' http://localhost:8545 || true)
+	echo $OUT | grep -q checksum && break
 	sleep 1
 done
 


### PR DESCRIPTION
We use `-dev` suffix to name the docker images that provide the **compilation** environment for the oasis-core, the key manager and similar. The `-dev` suffix for emerald and sapphire was picked before we started using the *Localnet* term more broadly, specific chain IDs etc. This PR renames the emerald and sapphire docker images running Localnet from `emerald-dev` and `sapphire-dev` to `emerald-localnet` and `sapphire-localnet` respectively to better reflect the actual usage.