### PR TITLE
feat: Bump Sapphire paratime version to 0.7.1-testnet

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -109,7 +109,7 @@ jobs:
       OASIS_CORE_VERSION: "23.0.9"
       OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
-      SAPPHIRE_PARATIME_VERSION: 0.7.0-testnet
+      SAPPHIRE_PARATIME_VERSION: 0.7.1-testnet
       GATEWAY__CHAIN_ID: 23293
       GATEWAY__OASIS_RPCS: true
       SAPPHIRE_PARATIME: ${{ github.workspace }}/oasis_core/sapphire-paratime

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache bash gcompat libseccomp jq binutils \
 
 # Docker-specific variables
 ENV OASIS_CORE_VERSION=23.0.9
-ENV PARATIME_VERSION=0.7.0
+ENV PARATIME_VERSION=0.7.1-testnet
 ENV PARATIME_NAME=sapphire
 ENV GATEWAY__CHAIN_ID=0x5afd
 

--- a/tests/rpc/rpc_test.go
+++ b/tests/rpc/rpc_test.go
@@ -176,9 +176,9 @@ func TestEth_GetBlockByNumberAndGetBlockByHash(t *testing.T) {
 		// Emerald Mainnet.
 		0xa516: 10_000_000,
 		// Sapphire Localnet.
-		0x5afd: 30_000_000,
+		0x5afd: 15_000_000,
 		// Sapphire Testnet.
-		0x5aff: 30_000_000,
+		0x5aff: 15_000_000,
 		// Sapphire Mainnet.
 		0x5afe: 15_000_000,
 	}


### PR DESCRIPTION
    sapphire-dev local (oasis-core: 23.0.9, sapphire-paratime: 0.7.1-testnet, oasis-web3-gateway: 4.0.2-git07081eb+dirty)

Noticed some errors when deploying contracts immediately after the container has started, they seem to resolve after a minute or two, trying to track down the cause.