### PR TITLE
feat: Reduce logging level in sapphire-localnet Docker image

### DIFF
--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -8,11 +8,15 @@ RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/commo
 FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-23.0.x AS oasis-core-dev
 
 ENV OASIS_UNSAFE_SKIP_KM_POLICY=1
+ENV OASIS_CORE_VERSION=stable/23.0.x
 ENV OASIS_CLI_VERSION=0.7.1
 
-RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch stable/23.0.x --depth 1 \
+RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch ${OASIS_CORE_VERSION} --depth 1 \
+	&& cd oasis-core/go/ \
+	&& make oasis-node oasis-net-runner \
+	&& cd ../../ \
 	&& cd oasis-core/tests/runtimes/simple-keymanager \
-	&& cargo build --release \
+	&& CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 cargo build --release \
 	&& cd ../../../../ \
 	&& git clone https://github.com/oasisprotocol/cli.git --branch v${OASIS_CLI_VERSION} --depth 1 \
 	&& cd cli \
@@ -24,12 +28,12 @@ RUN apk add --no-cache bash gcompat libseccomp jq binutils \
 	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
 
 # Docker-specific variables
-ENV OASIS_CORE_VERSION=23.0.9
 ENV PARATIME_VERSION=0.7.1-testnet
 ENV PARATIME_NAME=sapphire
 ENV GATEWAY__CHAIN_ID=0x5afd
 
 # start.sh and spinup-oasis-stack.sh ENV variables.
+ENV OASIS_NODE_LOG_LEVEL=warn
 ENV OASIS_NODE=/oasis-node
 ENV OASIS_NET_RUNNER=/oasis-net-runner
 ENV OASIS_NODE_DATADIR=/serverdir/node
@@ -38,17 +42,22 @@ ENV OASIS_DEPOSIT=/oasis-deposit
 ENV OASIS_WEB3_GATEWAY_CONFIG_FILE=/localnet.yml
 ENV PARATIME=/runtime.elf
 ENV KEYMANAGER_BINARY=/simple-keymanager
+ENV CLI_BINARY=/oasis
 ENV OASIS_UNSAFE_SKIP_AVR_VERIFY=1
 ENV OASIS_UNSAFE_SKIP_KM_POLICY=1
 ENV OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
 
 ARG VERSION
 
+# oasis-node and oasis-net-runner
+COPY --from=oasis-core-dev /oasis-core/go/oasis-node/oasis-node ${OASIS_NODE}
+COPY --from=oasis-core-dev /oasis-core/go/oasis-net-runner/oasis-net-runner ${OASIS_NET_RUNNER}
+
 # simple-keymanager
 COPY --from=oasis-core-dev /oasis-core/target/release/simple-keymanager ${KEYMANAGER_BINARY}
 
 # cli
-COPY --from=oasis-core-dev /cli/oasis /oasis
+COPY --from=oasis-core-dev /cli/oasis ${CLI_BINARY}
 
 # oasis-web3-gateway binary, config, spinup-* scripts and staking_genesis.json.
 COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY}
@@ -57,16 +66,8 @@ COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
 COPY docker/common/start.sh /
 COPY tests/tools/* /
 
-# Configure oasis-node and oasis-net-runner.
-RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"  \
-    && tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
-	&& mkdir -p "$(dirname ${OASIS_NODE})" "$(dirname ${OASIS_NET_RUNNER})" \
-	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE}" \
-	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}" \
-	&& rm "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
-	&& rm -rf "oasis_core_${OASIS_CORE_VERSION}_linux_amd64" \
-	&& echo "" \
-	&& echo "Configure the ParaTime." \
+# Configure paratime.
+RUN echo "Configure the ParaTime." \
 	&& mkdir -p "$(dirname ${PARATIME})" \
     && wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
     && unzip "paratime.orc" \
@@ -75,7 +76,7 @@ RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/
 	&& echo "" \
 	&& echo "Write VERSION information." \
 	&& echo "${VERSION}" > /VERSION \
-	&& strip -S -x ${OASIS_NET_RUNNER} ${OASIS_NODE} /oasis /simple-keymanager \
+	&& strip -S -x ${OASIS_NET_RUNNER} ${OASIS_NODE} ${KEYMANAGER_BINARY} ${CLI_BINARY} \
 	&& echo "" \
 	&& ls -l / \
 	&& echo "" \
@@ -83,7 +84,7 @@ RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/
 	&& ${OASIS_NODE} --version \
 	&& echo "" \
 	&& echo "*** Oasis CLI:" \
-	&& /oasis --version \
+	&& ${CLI_BINARY} --version \
 	&& echo ""
 
 # Web3 gateway http and ws ports.


### PR DESCRIPTION
This PR adds the following changes to the `sapphire-localnet` Docker image:
- Build `oasis-node` and `oasis-net-runner` from the `master` branch (needed until https://github.com/oasisprotocol/oasis-core/commit/522aeda9178662725c230c4cf353ea4dd47f9ce3 ends up in a stable release).
- Reduce size of built `simple-keymanager` binary from 5MB to 3MB (this is accomplished by tweaking Rust build options).
- Add env var to specify the log level of spawned nodes (`OASIS_NODE_LOG_LEVEL`).
- Reduce log level of all spawned nodes from `debug` to `warn`, which should result in a much much lower disk consumption.

TODO:
- [x] Measure disk space usage by logs at different log levels (`debug`, `info`, `warn`).
- [x] Backport the net runner log level changes to the `stable/23.0.x` branch.