### PR TITLE
fix(gas): gas price oracle improvements

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	Database *DatabaseConfig `koanf:"database"`
 	Gateway  *GatewayConfig  `koanf:"gateway"`
 
+	Gas *GasConfig `koanf:"gas"`
+
 	// ArchiveURI is the URI of an archival web3 gateway instance
 	// for servicing historical queries.
 	ArchiveURI string `koanf:"archive_uri"`
@@ -65,6 +67,11 @@ func (cfg *Config) Validate() error {
 	if cfg.Gateway != nil {
 		if err := cfg.Gateway.Validate(); err != nil {
 			return fmt.Errorf("gateway: %w", err)
+		}
+	}
+	if cfg.Gas != nil {
+		if err := cfg.Gas.Validate(); err != nil {
+			return fmt.Errorf("gas: %w", err)
 		}
 	}
 
@@ -224,6 +231,26 @@ type GatewayWSConfig struct {
 type MethodLimits struct {
 	// GetLogsMaxRounds is the maximum number of rounds to query for in a get logs query.
 	GetLogsMaxRounds uint64 `koanf:"get_logs_max_rounds"`
+}
+
+// GasConfig is the gas price oracle configuration.
+type GasConfig struct {
+	// MinGasPrice is the minimum gas price to accept for transactions.
+	MinGasPrice uint64 `koanf:"min_gas_price"`
+	// BlockFullThreshold is the percentage block gas used threshold to consider a block full.
+	BlockFullThreshold float64 `koanf:"block_full_threshold"`
+	// WindowSize is the number of past blocks to consider for gas price computation.
+	WindowSize uint64 `koanf:"window_size"`
+	// ComputedPriceMargin is the gas price to add to the computed gas price.
+	ComputedPriceMargin uint64 `koanf:"computed_price_margin"`
+}
+
+// Validate validates the gas configuration.
+func (cfg *GasConfig) Validate() error {
+	if cfg.BlockFullThreshold < 0 || cfg.BlockFullThreshold > 1 {
+		return fmt.Errorf("block full threshold must be in range [0, 1]")
+	}
+	return nil
 }
 
 // InitConfig initializes configuration from file.

--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -103,13 +103,13 @@ type BlockData struct {
 	Block      *model.Block
 	Receipts   []*model.Receipt
 	UniqueTxes []*model.Transaction
-	// LastTransactionPrice is the price of the last transaction in the runtime block in base units.
-	// This can be different than the price of the last transaction in the `BlockData.Block`
+	// MedianTransactionGasPrice is the price of the median transaction in the runtime block in base units.
+	// This can be different than the price of the median transaction in the `BlockData.Block`
 	// as `BlockData.Block` contains only EVM transactions.
 	// When https://github.com/oasisprotocol/oasis-web3-gateway/issues/84 is implemented
 	// this will need to be persisted in the DB, so that instances without the indexer can
 	// obtain this as well.
-	LastTransactionPrice *quantity.Quantity
+	MedianTransactionGasPrice *quantity.Quantity
 }
 
 // BackendObserver is the intrusive backend observer interaface.

--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func runRoot() error {
 		logger.Error("failed to create web3", err)
 		return err
 	}
-	gasPriceOracle := gas.New(ctx, backend, core.NewV1(rc))
+	gasPriceOracle := gas.New(ctx, cfg.Gas, backend, core.NewV1(rc))
 	if err = gasPriceOracle.Start(); err != nil {
 		logger.Error("failed to start gas price oracle", err)
 		return err

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -174,7 +174,7 @@ func Setup() error {
 		return fmt.Errorf("setup: failed creating server: %w", err)
 	}
 
-	gasPriceOracle = gas.New(ctx, backend, core.NewV1(rc))
+	gasPriceOracle = gas.New(ctx, tests.TestsConfig.Gas, backend, core.NewV1(rc))
 	if err = gasPriceOracle.Start(); err != nil {
 		return fmt.Errorf("setup: failed starting gas price oracle: %w", err)
 	}


### PR DESCRIPTION
Gas price oracle heuristics are updated to return better gas price estimates for the `eth_gasPrice` queries. Instead of returning the minimum gas price from the recent blocks, the maximum of the median gas price from recent full blocks is returned. Additionally the gas oracle parameters are now configurable, and the defaults are lowered to better detect full blocks.