### PR TITLE
fix: sapphire-localnet: Wait for postgres and the KM to be ready

### DIFF
--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch ${OASIS_C
 
 # Build sapphire-localnet
 FROM postgres:16-alpine
-RUN apk add --no-cache bash gcompat libseccomp jq binutils \
+RUN apk add --no-cache bash gcompat libseccomp jq binutils curl \
 	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
 
 # Docker-specific variables

--- a/docker/sapphire-localnet/test.sh
+++ b/docker/sapphire-localnet/test.sh
@@ -18,14 +18,14 @@ docker run -itd --rm -p8545:8545 --name "${NAME}" "${TAG}" -test-mnemonic >/dev/
 
 # Check, if depositing tokens to test accounts worked.
 while true; do
-	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65", "latest"],"id":1}' http://localhost:8545 || true)
+	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65", "latest"],"id":2}' http://localhost:8545 || true)
 	echo $OUT | grep -q 0x21e19e0c9bab2400000 && break
 	sleep 1
 done
 
 # Check, if public ephemeral key needed for c10l contracts exists.
 while true; do
-	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"oasis_callDataPublicKey","params":[],"id":2}' http://localhost:8545 || true)
+	OUT=$(curl -s -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"oasis_callDataPublicKey","params":[],"id":3}' http://localhost:8545 || true)
 	echo $OUT | grep -q checksum && break
 	sleep 1
 done


### PR DESCRIPTION
Postgres sometimes needs a bit more time to start up, which makes the gateway fail.  We now wait for it before starting the gateway.

Also, the key manager sometimes needs longer to generate the public ephemeral key needed for confidential contracts to work.  We now wait for the epehemeral key to become available before continuing with the rest of the container initialization.

Fixes #528.