### PR TITLE
fix: Log transaction data in Debug mode

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -416,7 +416,7 @@ func (api *publicAPI) Call(ctx context.Context, args utils.TransactionArgs, bloc
 
 func (api *publicAPI) SendRawTransaction(ctx context.Context, data hexutil.Bytes) (common.Hash, error) {
 	logger := api.Logger.With("method", "eth_sendRawTransaction")
-	logger.Debug("request", "length", len(data))
+	logger.Debug("request", "tx", data)
 
 	// Decode the Ethereum transaction.
 	ethTx := &ethtypes.Transaction{}


### PR DESCRIPTION
Since the Debug mode is the most verbose one and we typically use it when testing the sapphire-paratime middleware, it makes sense to log the transaction content as well, similar to how we already log the estimate gas and contract calls.