### PR TITLE
docker: Describe LOG__LEVEL for Web3 too

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -59,9 +59,12 @@ initialized each time you start the container!
 
 ## Debugging
 
-You can run the Docker container with `-e OASIS_NODE_LOG_LEVEL=debug` to increase
-the verbosity of messages logged.
+Within the Docker container, the Web3 gateway log messages reside in
+`/var/log/oasis-web3-gateway.log`. Logs from the Oasis node instances reside in
+the `node.log` files inside `/serverdir/node/net-runner/network` and a
+subfolder corresponding to each node's role.
 
-Additionally, you can view the gateway log messages from within the Docker container
-with `tail -f /var/log/oasis-web3-gateway.log`, and see additional network logs in
-this directory `/serverdir/node/net-runner/network/`.
+By default, the Oasis Web3 gateway and the Oasis node are configured with the
+*warn* verbosity level. To increase verbosity to *debug*, you can run the
+Docker container with `-e LOG__LEVEL=debug` for the Web3 gateway and
+`-e OASIS_NODE_LOG_LEVEL=debug` for the Oasis node.


### PR DESCRIPTION
This PR describes how to run Docker with setting both - the Web3 gateway and the Oasis node verbosity level to *debug*.