### PR TITLE
fix: go 1.22.1 fixes 'toolchain not available'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oasisprotocol/oasis-web3-gateway
 
-go 1.22
+go 1.22.1
 
 replace (
 	// Should be synced with Oasis Core as replace directives are not propagated.


### PR DESCRIPTION
This fixes a bug, without full revision specified in version, causes:

    go: downloading go1.22 (linux/amd64)
    go: download go1.22 for linux/amd64: toolchain not available

The discussion is available at: https://github.com/golang/go/issues/62278