### PR TITLE
sapphire-localnet: Use Mock SGX for spinning up Oasis stack

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -113,7 +113,7 @@ jobs:
       GATEWAY__CHAIN_ID: 23293
       GATEWAY__OASIS_RPCS: true
       SAPPHIRE_PARATIME: ${{ github.workspace }}/oasis_core/sapphire-paratime
-      KEYMANAGER_ARTIFACT_URL: https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/13622/jobs/018fb976-afd1-442d-a628-7b61a0c234a5/artifacts/018fb97b-3100-4035-b1ca-4295076e9ec3 # Find this at https://buildkite.com/oasisprotocol/oasis-core-ci/builds?branch=stable%2F<...> under "Build runtimes".
+      KEYMANAGER_ARTIFACT_URL: https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/14038/jobs/0191c151-b95b-402c-9854-4e58effc95ab/artifacts/0191c156-f366-45b2-819b-e1eb9fd9ba16 # Find this at https://buildkite.com/oasisprotocol/oasis-core-ci/builds?branch=stable%2F<...> under "Build runtimes": simple-keymanager.mocksgx.
       KEYMANAGER_BINARY: ${{ github.workspace }}/oasis_core/simple-keymanager
       OASIS_NODE_DATADIR: /tmp/eth-runtime-test
     steps:
@@ -165,6 +165,7 @@ jobs:
           name: oasis-node-logs-c10l
           path: |
             ${{ env.OASIS_NODE_DATADIR }}/**/*.log
+            ${{ env.OASIS_NODE_DATADIR }}/**/config.yaml
             ${{ env.OASIS_NODE_DATADIR }}/fixture.json
 
       - name: Upload to codecov.io

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -35,9 +35,9 @@ jobs:
         ports:
           - 5432:5432
     env:
-      OASIS_CORE_VERSION: "24.1"
-      OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
-      OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
+      OASIS_CORE_VERSION: "24.2"
+      OASIS_NODE_BINARY: ${{ github.workspace }}/oasis_core/oasis-node
+      OASIS_NET_RUNNER_BINARY: ${{ github.workspace }}/oasis_core/oasis-net-runner
       EMERALD_PARATIME_VERSION: 11.0.0-testnet
       GATEWAY__CHAIN_ID: 42260
       EMERALD_PARATIME: ${{ github.workspace }}/oasis_core/emerald-paratime
@@ -56,10 +56,10 @@ jobs:
           sudo apt update && sudo apt install bubblewrap unzip -y
           wget "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
           tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
-          mkdir -p "$(dirname ${OASIS_NODE})"
-          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE}"
-          mkdir -p "$(dirname ${OASIS_NET_RUNNER})"
-          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}"
+          mkdir -p "$(dirname ${OASIS_NODE_BINARY})"
+          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE_BINARY}"
+          mkdir -p "$(dirname ${OASIS_NET_RUNNER_BINARY})"
+          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER_BINARY}"
           mkdir -p "$(dirname ${EMERALD_PARATIME})"
           wget "https://github.com/oasisprotocol/emerald-paratime/releases/download/v${EMERALD_PARATIME_VERSION}/localnet-emerald-paratime.orc" -O "${EMERALD_PARATIME}.orc"
           unzip "${EMERALD_PARATIME}.orc"
@@ -68,7 +68,7 @@ jobs:
 
       - name: Spinup oasis-node
         run:
-          PARATIME="${EMERALD_PARATIME}" PARATIME_VERSION="${EMERALD_PARATIME_VERSION}" tests/tools/spinup-oasis-stack.sh > /dev/null &
+          PARATIME_BINARY="${EMERALD_PARATIME}" PARATIME_VERSION="${EMERALD_PARATIME_VERSION}" tests/tools/spinup-oasis-stack.sh > /dev/null &
           sleep 60
 
       - name: Unit tests with coverage
@@ -106,10 +106,10 @@ jobs:
         ports:
           - 5432:5432
     env:
-      OASIS_CORE_VERSION: "24.1"
-      OASIS_NODE: ${{ github.workspace }}/oasis_core/oasis-node
-      OASIS_NET_RUNNER: ${{ github.workspace }}/oasis_core/oasis-net-runner
-      SAPPHIRE_PARATIME_VERSION: 0.8.1-testnet
+      OASIS_CORE_VERSION: "24.2"
+      OASIS_NODE_BINARY: ${{ github.workspace }}/oasis_core/oasis-node
+      OASIS_NET_RUNNER_BINARY: ${{ github.workspace }}/oasis_core/oasis-net-runner
+      SAPPHIRE_PARATIME_VERSION: 0.8.2-testnet
       GATEWAY__CHAIN_ID: 23293
       GATEWAY__OASIS_RPCS: true
       SAPPHIRE_PARATIME: ${{ github.workspace }}/oasis_core/sapphire-paratime
@@ -131,10 +131,10 @@ jobs:
           # oasis-core
           wget "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
           tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"
-          mkdir -p "$(dirname ${OASIS_NODE})"
-          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE}"
-          mkdir -p "$(dirname ${OASIS_NET_RUNNER})"
-          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}"
+          mkdir -p "$(dirname ${OASIS_NODE_BINARY})"
+          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE_BINARY}"
+          mkdir -p "$(dirname ${OASIS_NET_RUNNER_BINARY})"
+          mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER_BINARY}"
           mkdir -p "$(dirname ${SAPPHIRE_PARATIME})"
           # sapphire-paratime
           wget "https://github.com/oasisprotocol/sapphire-paratime/releases/download/v${SAPPHIRE_PARATIME_VERSION}/localnet-sapphire-paratime.orc" -O "${SAPPHIRE_PARATIME}.orc"
@@ -146,7 +146,7 @@ jobs:
 
       - name: Spinup oasis-node
         run:
-          PARATIME="${SAPPHIRE_PARATIME}" PARATIME_VERSION="${SAPPHIRE_PARATIME_VERSION}" tests/tools/spinup-oasis-stack.sh > /dev/null &
+          PARATIME_BINARY="${SAPPHIRE_PARATIME}" PARATIME_VERSION="${SAPPHIRE_PARATIME_VERSION}" OASIS_UNSAFE_SKIP_AVR_VERIFY=1 OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1 OASIS_UNSAFE_MOCK_SGX=1 tests/tools/spinup-oasis-stack.sh > /dev/null &
           sleep 60
 
       - name: Unit tests with coverage

--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -1,5 +1,5 @@
 # Build oasis-web3-gateway
-FROM golang:1.22 AS oasis-web3-gateway
+FROM golang:1.22.3 AS oasis-web3-gateway
 
 COPY . /go/oasis-web3-gateway
 RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/common/oasis-deposit/oasis-deposit
@@ -10,8 +10,8 @@ RUN apk add --no-cache bash gcompat libseccomp jq binutils \
 	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
 
 # Docker-specific variables
-ENV OASIS_CORE_VERSION=24.0
-ENV OASIS_CLI_VERSION=0.8.1
+ENV OASIS_CORE_VERSION=24.2
+ENV OASIS_CLI_VERSION=0.10.0
 ENV PARATIME_VERSION=11.0.0-testnet
 ENV PARATIME_NAME=emerald
 ENV GATEWAY__CHAIN_ID=0xa514

--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -17,20 +17,21 @@ ENV PARATIME_NAME=emerald
 ENV GATEWAY__CHAIN_ID=0xa514
 
 # start.sh and spinup-oasis-stack.sh ENV variables.
-ENV OASIS_NODE=/oasis-node
-ENV OASIS_NET_RUNNER=/oasis-net-runner
+ENV OASIS_NODE_BINARY=/oasis-node
+ENV OASIS_NET_RUNNER_BINARY=/oasis-net-runner
 ENV OASIS_NODE_DATADIR=/serverdir/node
-ENV OASIS_WEB3_GATEWAY=/oasis-web3-gateway
-ENV OASIS_DEPOSIT=/oasis-deposit
+ENV OASIS_WEB3_GATEWAY_BINARY=/oasis-web3-gateway
+ENV OASIS_DEPOSIT_BINARY=/oasis-deposit
 ENV OASIS_WEB3_GATEWAY_CONFIG_FILE=/localnet.yml
-ENV PARATIME=/runtime.elf
+ENV PARATIME_BINARY=/runtime.elf
 ENV KEYMANAGER_BINARY=""
+ENV OASIS_CLI_BINARY=/oasis
 
 ARG VERSION
 
 # oasis-web3-gateway binary, config, spinup-* scripts and staking_genesis.json.
-COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY}
-COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/docker/common/oasis-deposit/oasis-deposit ${OASIS_DEPOSIT}
+COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY_BINARY}
+COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/docker/common/oasis-deposit/oasis-deposit ${OASIS_DEPOSIT_BINARY}
 COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
 COPY docker/common/start.sh /
 COPY tests/tools/* /
@@ -38,14 +39,14 @@ COPY tests/tools/* /
 # Configure oasis-node and oasis-net-runner.
 RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"  \
 	&& tar xfvz "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
-	&& mkdir -p "$(dirname ${OASIS_NODE})" "$(dirname ${OASIS_NET_RUNNER})" \
-	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE}" \
-	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER}" \
+	&& mkdir -p "$(dirname ${OASIS_NODE_BINARY})" "$(dirname ${OASIS_NET_RUNNER_BINARY})" \
+	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node" "${OASIS_NODE_BINARY}" \
+	&& mv "oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner" "${OASIS_NET_RUNNER_BINARY}" \
 	&& rm "oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz" \
 	&& rm -rf "oasis_core_${OASIS_CORE_VERSION}_linux_amd64" \
 	&& echo "" \
 	&& echo "Configure the ParaTime." \
-	&& mkdir -p "$(dirname ${PARATIME})" \
+	&& mkdir -p "$(dirname ${PARATIME_BINARY})" \
 	&& wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
 	&& unzip "paratime.orc" \
 	&& chmod a+x "runtime.elf" \
@@ -60,7 +61,7 @@ RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/
 	&& echo "" \
 	&& echo "Write VERSION information." \
 	&& echo "${VERSION}" > /VERSION \
-	&& strip -S -x /oasis-net-runner /oasis-node /oasis
+	&& strip -S -x ${OASIS_NET_RUNNER_BINARY} ${OASIS_NODE_BINARY} ${OASIS_CLI_BINARY}
 
 # Web3 gateway http and ws ports.
 EXPOSE 8545/tcp

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -1,24 +1,27 @@
 # Build oasis-web3-gateway
-FROM golang:1.22 AS oasis-web3-gateway
+FROM golang:1.22.3 AS oasis-web3-gateway
 
 COPY . /go/oasis-web3-gateway
 RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/common/oasis-deposit/oasis-deposit
 
 # Build simple-keymanager
-FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-24.0.x AS oasis-core-dev
+FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-24.2.x AS oasis-core-dev
 
-ENV OASIS_UNSAFE_SKIP_KM_POLICY=1
+ENV OASIS_UNSAFE_MOCK_SGX=1
 ENV OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
-ENV OASIS_CORE_VERSION=stable/24.1.x
-ENV OASIS_CLI_VERSION=0.9.0
+ENV OASIS_CORE_VERSION=stable/24.2.x
+ENV OASIS_CLI_VERSION=0.10.0
 
 RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch ${OASIS_CORE_VERSION} --depth 1 \
 	&& cd oasis-core/go/ \
 	&& make oasis-node oasis-net-runner \
 	&& cd ../../ \
 	&& cd oasis-core/tests/runtimes/simple-keymanager \
-	&& CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 cargo build --release \
+	&& CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 OASIS_UNSAFE_SKIP_AVR_VERIFY=1 cargo build --release --features debug-mock-sgx \
 	&& cd ../../../../ \
+    && cd oasis-core \
+    && cargo build -p oasis-core-runtime-loader --release \
+    && cd .. \
 	&& git clone https://github.com/oasisprotocol/cli.git --branch v${OASIS_CLI_VERSION} --depth 1 \
 	&& cd cli \
 	&& make CGO_ENABLED=0
@@ -45,8 +48,8 @@ ENV PARATIME=/ronl.elf
 ENV KEYMANAGER_BINARY=/simple-keymanager
 ENV CLI_BINARY=/oasis
 ENV OASIS_UNSAFE_SKIP_AVR_VERIFY=1
-ENV OASIS_UNSAFE_SKIP_KM_POLICY=1
 ENV OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
+ENV OASIS_UNSAFE_MOCK_SGX=1
 
 ARG VERSION
 
@@ -56,6 +59,9 @@ COPY --from=oasis-core-dev /oasis-core/go/oasis-net-runner/oasis-net-runner ${OA
 
 # simple-keymanager
 COPY --from=oasis-core-dev /oasis-core/target/release/simple-keymanager ${KEYMANAGER_BINARY}
+
+# oasis-core-runtime-loader
+COPY --from=oasis-core-dev /oasis-core/target/release/oasis-core-runtime-loader ${OASIS_CORE_RUNTIME_LOADER}
 
 # cli
 COPY --from=oasis-core-dev /cli/oasis ${CLI_BINARY}
@@ -68,13 +74,15 @@ COPY docker/common/start.sh /
 COPY tests/tools/* /
 
 # Configure paratime.
+# XXX: Build locally.
+COPY docker/sapphire-localnet/sapphire-paratime ${PARATIME}
 RUN echo "Configure the ParaTime." \
-	&& mkdir -p "$(dirname ${PARATIME})" \
-    && wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
-    && unzip "paratime.orc" \
-    && chmod a+x "ronl.elf" \
-	&& rm "paratime.orc" \
-	&& echo "" \
+#	&& mkdir -p "$(dirname ${PARATIME})" \
+#   && wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
+#   && unzip "paratime.orc" \
+#   && chmod a+x "runtime.elf" \
+#	&& rm "paratime.orc" \
+#	&& echo "" \
 	&& echo "Write VERSION information." \
 	&& echo "${VERSION}" > /VERSION \
 	&& strip -S -x ${OASIS_NET_RUNNER} ${OASIS_NODE} ${KEYMANAGER_BINARY} ${CLI_BINARY} \

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -1,100 +1,137 @@
-# Build oasis-web3-gateway
-FROM golang:1.22.3 AS oasis-web3-gateway
+ARG PARATIME_VERSION=0.8.2-testnet
+ARG PARATIME_NAME=sapphire
 
-COPY . /go/oasis-web3-gateway
-RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/common/oasis-deposit/oasis-deposit
-
-# Build simple-keymanager
+# Build simple-keymanager, oasis-deposit and, fetch (or optionally build) other components.
 FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-24.2.x AS oasis-core-dev
 
-ENV OASIS_UNSAFE_MOCK_SGX=1
-ENV OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
-ENV OASIS_CORE_VERSION=stable/24.2.x
-ENV OASIS_CLI_VERSION=0.10.0
+ENV OASIS_CORE_SIMPLE_KM_BRANCH=stable/24.2.x
+RUN git clone https://github.com/oasisprotocol/oasis-core.git oasis-core-km --branch ${OASIS_CORE_SIMPLE_KM_BRANCH} --depth 1 \
+    && cd /oasis-core-km/tests/runtimes/simple-keymanager \
+    && OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1 CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 OASIS_UNSAFE_SKIP_AVR_VERIFY=1 \
+    cargo build --release --features debug-mock-sgx \
+    && strip -S -x /oasis-core-km/target/release/simple-keymanager \
+    && mv /oasis-core-km/target/release/simple-keymanager / \
+    && rm -rf /oasis-core-km
 
-RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch ${OASIS_CORE_VERSION} --depth 1 \
-	&& cd oasis-core/go/ \
-	&& make oasis-node oasis-net-runner \
-	&& cd ../../ \
-	&& cd oasis-core/tests/runtimes/simple-keymanager \
-	&& CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 OASIS_UNSAFE_SKIP_AVR_VERIFY=1 cargo build --release --features debug-mock-sgx \
-	&& cd ../../../../ \
-    && cd oasis-core \
-    && cargo build -p oasis-core-runtime-loader --release \
-    && cd .. \
-	&& git clone https://github.com/oasisprotocol/cli.git --branch v${OASIS_CLI_VERSION} --depth 1 \
-	&& cd cli \
-	&& make CGO_ENABLED=0
+COPY docker/common/oasis-deposit /oasis-deposit-git
+RUN cd oasis-deposit-git \
+    && go build \
+    && strip -S -x /oasis-deposit-git/oasis-deposit \
+    && mv /oasis-deposit-git/oasis-deposit / \
+    && rm -rf /oasis-deposit-git
+
+# Fetch latest released components. Replace with commented snippet below to build manually.
+ENV OASIS_CORE_VERSION=24.2
+RUN wget https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz \
+    && tar -zxvf oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz \
+    && strip -S -x oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner \
+    && mv oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-node oasis_core_${OASIS_CORE_VERSION}_linux_amd64/oasis-net-runner / \
+    && rm -rf /oasis_core_${OASIS_CORE_VERSION}_linux_amd64*
+#ENV OASIS_CORE_BRANCH=stable/24.2.x
+#RUN git clone https://github.com/oasisprotocol/oasis-core.git --branch ${OASIS_CORE_BRANCH} --depth 1 \
+#    && cd /oasis-core \
+#    && make -C go oasis-node oasis-net-runner \
+#    && strip -S -x /oasis-core/go/oasis-net-runner/oasis-net-runner /oasis-core/go/oasis-node/oasis-node \
+#    && mv /oasis-core/go/oasis-net-runner/oasis-net-runner /oasis-core/go/oasis-node/oasis-node / \
+#    && rm -rf /oasis-core
+
+ENV OASIS_CLI_VERSION=0.10.0
+RUN wget https://github.com/oasisprotocol/cli/releases/download/v${OASIS_CLI_VERSION}/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz \
+    && tar -zxvf oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz \
+    && strip -S -x /oasis_cli_${OASIS_CLI_VERSION}_linux_amd64/oasis \
+    && mv /oasis_cli_${OASIS_CLI_VERSION}_linux_amd64/oasis / \
+    && rm -rf /oasis_cli_${OASIS_CLI_VERSION}_linux_amd64*
+#ENV OASIS_CLI_BRANCH=master
+#RUN git clone https://github.com/oasisprotocol/cli.git --branch ${OASIS_CLI_BRANCH} --depth 1 \
+#    && make -C cli CGO_ENABLED=0 \
+#    && strip -S -x /cli/oasis
+#    && mv /cli/oasis / \
+#    && rm -rf cli
+
+ENV OASIS_WEB3_GATEWAY_VERSION=5.1.0
+RUN wget https://github.com/oasisprotocol/oasis-web3-gateway/releases/download/v${OASIS_WEB3_GATEWAY_VERSION}/oasis_web3_gateway_${OASIS_WEB3_GATEWAY_VERSION}_linux_amd64.tar.gz \
+    && tar -zxvf oasis_web3_gateway_${OASIS_WEB3_GATEWAY_VERSION}_linux_amd64.tar.gz \
+    && strip -S -x /oasis_web3_gateway_${OASIS_WEB3_GATEWAY_VERSION}_linux_amd64/oasis-web3-gateway \
+    && mv /oasis_web3_gateway_${OASIS_WEB3_GATEWAY_VERSION}_linux_amd64/oasis-web3-gateway / \
+    && rm -rf /oasis_web3_gateway_${OASIS_WEB3_GATEWAY_VERSION}_linux_amd64*
+#ENV OASIS_WEB3_GATEWAY_BRANCH=main
+#RUN git clone https://github.com/oasisprotocol/oasis-web3-gateway.git oasis-web3-gateway-git --branch ${OASIS_WEB3_GATEWAY_BRANCH} --depth 1 \
+#    && make -C oasis-web3-gateway-git \
+#    && strip -S -x /oasis-web3-gateway-git/oasis-web3-gateway \
+#    && mv /oasis-web3-gateway-git/oasis-web3-gateway / \
+#    && rm -rf /oasis-web3-gateway-git
+
+ARG PARATIME_VERSION
+ARG PARATIME_NAME
+RUN wget https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc \
+    && unzip "localnet-${PARATIME_NAME}-paratime.orc" "ronl.elf" \
+    && chmod a+x "ronl.elf" \
+    && mv "ronl.elf" "sapphire-paratime" \
+    && strip -S -x "sapphire-paratime" \
+    && rm "localnet-${PARATIME_NAME}-paratime.orc"
+#ENV OASIS_SAPPHIRE_PARATIME_BRANCH=main
+#RUN git clone https://github.com/oasisprotocol/sapphire-paratime.git sapphire-paratime-git --branch ${OASIS_SAPPHIRE_PARATIME_BRANCH} --depth 1 \
+#    && cd sapphire-paratime-git/runtime \
+#    && OASIS_UNSAFE_SKIP_AVR_VERIFY=1 OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1 OASIS_UNSAFE_USE_LOCALNET_CHAINID=1 \
+#    cargo build --release --locked --features debug-mock-sgx \
+#    && strip -S -x /sapphire-paratime-git/runtime/target/release/sapphire-paratime \
+#    && mv /sapphire-paratime-git/runtime/target/release/sapphire-paratime / \
+#    && rm -rf sapphire-paratime-git
 
 # Build sapphire-localnet
 FROM postgres:16-alpine
 RUN apk add --no-cache bash gcompat libseccomp jq binutils curl \
-	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
+    && su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
 
 # Docker-specific variables
-ENV PARATIME_VERSION=0.8.1-testnet
-ENV PARATIME_NAME=sapphire
+ARG PARATIME_VERSION
+ARG PARATIME_NAME
+ENV PARATIME_VERSION=${PARATIME_VERSION}
+ENV PARATIME_NAME=${PARATIME_NAME}
 ENV GATEWAY__CHAIN_ID=0x5afd
 
 # start.sh and spinup-oasis-stack.sh ENV variables.
 ENV OASIS_NODE_LOG_LEVEL=warn
-ENV OASIS_NODE=/oasis-node
-ENV OASIS_NET_RUNNER=/oasis-net-runner
+ENV OASIS_NODE_BINARY=/oasis-node
+ENV OASIS_NET_RUNNER_BINARY=/oasis-net-runner
 ENV OASIS_NODE_DATADIR=/serverdir/node
-ENV OASIS_WEB3_GATEWAY=/oasis-web3-gateway
-ENV OASIS_DEPOSIT=/oasis-deposit
+ENV OASIS_WEB3_GATEWAY_BINARY=/oasis-web3-gateway
+ENV OASIS_DEPOSIT_BINARY=/oasis-deposit
 ENV OASIS_WEB3_GATEWAY_CONFIG_FILE=/localnet.yml
-ENV PARATIME=/ronl.elf
+ENV PARATIME_BINARY=/ronl.elf
 ENV KEYMANAGER_BINARY=/simple-keymanager
-ENV CLI_BINARY=/oasis
+ENV OASIS_CLI_BINARY=/oasis
 ENV OASIS_UNSAFE_SKIP_AVR_VERIFY=1
 ENV OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1
 ENV OASIS_UNSAFE_MOCK_SGX=1
 
 ARG VERSION
 
-# oasis-node and oasis-net-runner
-COPY --from=oasis-core-dev /oasis-core/go/oasis-node/oasis-node ${OASIS_NODE}
-COPY --from=oasis-core-dev /oasis-core/go/oasis-net-runner/oasis-net-runner ${OASIS_NET_RUNNER}
+# Copy local builds.
+COPY --from=oasis-core-dev /simple-keymanager ${KEYMANAGER_BINARY}
+COPY --from=oasis-core-dev /oasis-deposit ${OASIS_DEPOSIT_BINARY}
+COPY --from=oasis-core-dev /oasis-web3-gateway ${OASIS_WEB3_GATEWAY_BINARY}
+COPY --from=oasis-core-dev /oasis-node ${OASIS_NODE_BINARY}
+COPY --from=oasis-core-dev /oasis-net-runner ${OASIS_NET_RUNNER_BINARY}
+COPY --from=oasis-core-dev /oasis ${OASIS_CLI_BINARY}
+COPY --from=oasis-core-dev /sapphire-paratime ${PARATIME_BINARY}
 
-# simple-keymanager
-COPY --from=oasis-core-dev /oasis-core/target/release/simple-keymanager ${KEYMANAGER_BINARY}
-
-# oasis-core-runtime-loader
-COPY --from=oasis-core-dev /oasis-core/target/release/oasis-core-runtime-loader ${OASIS_CORE_RUNTIME_LOADER}
-
-# cli
-COPY --from=oasis-core-dev /cli/oasis ${CLI_BINARY}
-
-# oasis-web3-gateway binary, config, spinup-* scripts and staking_genesis.json.
-COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY}
-COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/docker/common/oasis-deposit/oasis-deposit ${OASIS_DEPOSIT}
 COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
 COPY docker/common/start.sh /
 COPY tests/tools/* /
 
 # Configure paratime.
-# XXX: Build locally.
-COPY docker/sapphire-localnet/sapphire-paratime ${PARATIME}
-RUN echo "Configure the ParaTime." \
-#	&& mkdir -p "$(dirname ${PARATIME})" \
-#   && wget --quiet "https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc" -O "/paratime.orc" \
-#   && unzip "paratime.orc" \
-#   && chmod a+x "runtime.elf" \
-#	&& rm "paratime.orc" \
-#	&& echo "" \
-	&& echo "Write VERSION information." \
-	&& echo "${VERSION}" > /VERSION \
-	&& strip -S -x ${OASIS_NET_RUNNER} ${OASIS_NODE} ${KEYMANAGER_BINARY} ${CLI_BINARY} \
-	&& echo "" \
-	&& ls -l / \
-	&& echo "" \
-	&& echo "*** Oasis Node:" \
-	&& ${OASIS_NODE} --version \
-	&& echo "" \
-	&& echo "*** Oasis CLI:" \
-	&& ${CLI_BINARY} --version \
-	&& echo ""
+RUN echo "Write VERSION information." \
+    && echo "${VERSION}" > /VERSION \
+    && echo \
+    && ls -l / \
+    && echo \
+    && echo "*** Oasis Node:" \
+    && ${OASIS_NODE_BINARY} --version \
+    && echo \
+    && echo "*** Oasis CLI:" \
+    && ${OASIS_CLI_BINARY} --version \
+    && echo
 
 # Web3 gateway http and ws ports.
 EXPOSE 8545/tcp

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 
 # This script spins up local oasis node configured with the provided EVM ParaTime.
 # Supported ENV Variables:
-# - OASIS_NODE: path to oasis-node binary
-# - OASIS_NET_RUNNER: path to oasis-net-runner binary
+# - OASIS_NODE_BINARY: path to oasis-node binary
+# - OASIS_NET_RUNNER_BINARY: path to oasis-net-runner binary
 # - BEACON_BACKEND: choose 'mock' backend (default), or use other behavior
-# - PARATIME: path to ParaTime binary (inside .orc bundle)
+# - PARATIME_BINARY: path to ParaTime binary (inside .orc bundle)
 # - PARATIME_VERSION: version of the binary. e.g. 3.0.0
 # - OASIS_NODE_DATADIR: path to temporary oasis-node data dir e.g. /tmp/oasis-localnet
 # - KEYMANAGER_BINARY: path to key manager binary e.g. simple-keymanager
@@ -32,14 +32,14 @@ if [ ! -z "${KEYMANAGER_BINARY:-}" ]; then
 fi
 
 # Prepare configuration for oasis-node (fixture).
-${OASIS_NET_RUNNER} dump-fixture \
+${OASIS_NET_RUNNER_BINARY} dump-fixture \
   --fixture.default.tee_hardware "${TEE_HARDWARE}" \
-  --fixture.default.node.binary "${OASIS_NODE}" \
+  --fixture.default.node.binary "${OASIS_NODE_BINARY}" \
   --fixture.default.deterministic_entities \
   --fixture.default.fund_entities \
   --fixture.default.num_entities 2 \
   --fixture.default.keymanager.binary "${KEYMANAGER_BINARY:-}" \
-  --fixture.default.runtime.binary "${PARATIME}" \
+  --fixture.default.runtime.binary "${PARATIME_BINARY}" \
   --fixture.default.runtime.provisioner "unconfined" \
   --fixture.default.runtime.version "$(paratime_ver 1).$(paratime_ver 2).$(paratime_ver 3)" \
   --fixture.default.halt_epoch 100000 \
@@ -55,7 +55,7 @@ fi
 if [ ! -z "${KEYMANAGER_BINARY:-}" ]; then
   jq "
     .runtimes[0].deployments[0].components[0].binaries.\"0\" = \"${KEYMANAGER_BINARY}\" |
-    .runtimes[${RT_IDX}].deployments[0].components[0].binaries.\"0\" = \"${PARATIME}\"
+    .runtimes[${RT_IDX}].deployments[0].components[0].binaries.\"0\" = \"${PARATIME_BINARY}\"
   " "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
   mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 fi
@@ -106,4 +106,4 @@ jq ".runtimes[${RT_IDX}].txn_scheduler.batch_flush_timeout=1000000000" "$FIXTURE
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
 # Run oasis-node.
-${OASIS_NET_RUNNER} --fixture.file "$FIXTURE_FILE" --basedir "${OASIS_NODE_DATADIR}" --basedir.no_temp_dir $@
+${OASIS_NET_RUNNER_BINARY} --fixture.file "$FIXTURE_FILE" --basedir "${OASIS_NODE_DATADIR}" --basedir.no_temp_dir $@


### PR DESCRIPTION
This PR:
- Implements https://github.com/oasisprotocol/sapphire-paratime/issues/356 for sapphire-localnet docker images.
- Revamps the Dockerfiles so that you can pick whether you want to build components from git sources or just download the releases. Both is done in `oasis-core-dev` image now, so this reduced the final sapphire-localnet image size from ~598MB to ~434MB.

Merge after https://github.com/oasisprotocol/sapphire-paratime/pull/357