### PR TITLE
fix: Add script that waits until container startup is done

### DIFF
--- a/docker/common/wait-container-ready.sh
+++ b/docker/common/wait-container-ready.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+sleep 1; while [ ! -f /CONTAINER_READY ]; do sleep 1; done
+exit 0

--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS
 COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/docker/common/oasis-deposit/oasis-deposit ${OASIS_DEPOSIT_BINARY}
 COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
 COPY docker/common/start.sh /
+COPY docker/common/wait-container-ready.sh /
 COPY tests/tools/* /
 
 # Configure oasis-node and oasis-net-runner.

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -118,6 +118,7 @@ COPY --from=oasis-core-dev /sapphire-paratime ${PARATIME_BINARY}
 
 COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
 COPY docker/common/start.sh /
+COPY docker/common/wait-container-ready.sh /
 COPY tests/tools/* /
 
 # Configure paratime.


### PR DESCRIPTION
This PR adds a `/wait-container-ready.sh` script to the `sapphire-localnet` and `emerald-localnet` Docker images, so that external tools and processes can just run that and it will wait until the local network has fully finished starting up and all test accounts are populated.