### PR TITLE
sapphire-localnet: Add support for running ROFLs

### DIFF
--- a/docker/common/oasis-deposit/main.go
+++ b/docker/common/oasis-deposit/main.go
@@ -177,7 +177,7 @@ func main() {
 	sock := flag.String("sock", "", "oasis-node internal UNIX socket address")
 	rtid := flag.String("rtid", "8000000000000000000000000000000000000000000000000000000000000000", "Runtime ID")
 	to := flag.String("to", "", "comma-separated deposit addresses in 0x or oasis1 format or mnemonic phrase. If none provided, new mnemonic will be generated")
-	useTestMnemonic := flag.Bool("test-mnemonic", false, "Use the standard test mnemonic (test test test test test test test test test test test junk)")
+	useTestMnemonic := flag.Bool("test-mnemonic", true, "Use the standard test mnemonic (test test test test test test test test test test test junk)")
 	flag.IntVar(&numMnemonicDerivations, "n", numMnemonicDerivations, "number of addresses to derive from mnemonic")
 	flag.Parse()
 

--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -42,61 +42,61 @@ OASIS_NODE_PID=""
 set -euo pipefail
 
 function cleanup {
-    if [[ -n "${OASIS_WEB3_GATEWAY_PID}" ]]; then
-        kill -9 ${OASIS_WEB3_GATEWAY_PID}
-    fi
-    if [[ -n "${OASIS_NODE_PID}" ]]; then
-        kill -9 ${OASIS_NODE_PID}
-    fi
+  if [[ -n "${OASIS_WEB3_GATEWAY_PID}" ]]; then
+    kill -9 ${OASIS_WEB3_GATEWAY_PID}
+  fi
+  if [[ -n "${OASIS_NODE_PID}" ]]; then
+    kill -9 ${OASIS_NODE_PID}
+  fi
 }
 
 trap cleanup INT TERM EXIT
 
 # If we have an interactive terminal, use colors.
 if [[ -t 0 ]]; then
-    GREEN="\e[32;1m"
-    YELLOW="\e[33;1m"
-    CYAN="\e[36;1m"
-    OFF="\e[0m"
+  GREEN="\e[32;1m"
+  YELLOW="\e[33;1m"
+  CYAN="\e[36;1m"
+  OFF="\e[0m"
 else
-    GREEN=""
-    YELLOW=""
-    CYAN=""
-    OFF=""
+  GREEN=""
+  YELLOW=""
+  CYAN=""
+  OFF=""
 fi
 
 if [[ "x${OASIS_DOCKER_USE_TIMESTAMPS_IN_NOTICES}" == "xyes" ]]; then
-function notice {
+  function notice {
     printf "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${OFF} $@"
-}
-else
-function notice {
+  }
+  else
+  function notice {
     printf "${CYAN} *${OFF} $@"
-}
+  }
 fi
 
 if [[ "${OASIS_NODE_LOG_LEVEL}" == "debug" ]]; then
-    if [[ "x${OASIS_DOCKER_USE_TIMESTAMPS_IN_NOTICES}" == "xyes" ]]; then
-    function notice_debug {
-        if [ "$1" == "-l" ]; then
-            shift
-            printf "\n"
-        fi
-        printf "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${OFF} $@"
-    }
-    else
-    function notice_debug {
-        if [ "$1" == "-l" ]; then
-            shift
-            printf "\n"
-        fi
-        printf "${CYAN} *${OFF} $@"
-    }
+  if [[ "x${OASIS_DOCKER_USE_TIMESTAMPS_IN_NOTICES}" == "xyes" ]]; then
+  function notice_debug {
+    if [ "$1" == "-l" ]; then
+      shift
+      printf "\n"
     fi
+    printf "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${OFF} $@"
+  }
+  else
+  function notice_debug {
+    if [ "$1" == "-l" ]; then
+      shift
+      printf "\n"
+    fi
+    printf "${CYAN} *${OFF} $@"
+  }
+  fi
 else
-    notice_debug() {
-        :
-    }
+  notice_debug() {
+    :
+  }
 fi
 
 T_START="$(date +%s)"
@@ -123,7 +123,7 @@ OASIS_NODE_PID=$!
 notice "Waiting for Postgres to start"
 su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres 2>1 &>/var/log/postgres.log
 function is_postgres_ready() {
-    pg_isready -h 127.0.0.1 -p 5432 2>1 &>/dev/null
+  pg_isready -h 127.0.0.1 -p 5432 2>1 &>/dev/null
 }
 until is_postgres_ready; do echo -n .; sleep 1; done
 echo
@@ -141,64 +141,64 @@ chmod 755 /serverdir/node/net-runner/network/client-0/
 chmod a+rw /serverdir/node/net-runner/network/client-0/internal.sock
 
 if [[ "x${OASIS_DOCKER_NO_GATEWAY}" == "xyes" ]]; then
-    notice "Skipping oasis-web3-gateway start-up...\n"
+  notice "Skipping oasis-web3-gateway start-up...\n"
 else
-    notice "Starting oasis-web3-gateway...\n"
-    ${OASIS_WEB3_GATEWAY_BINARY} --config ${OASIS_WEB3_GATEWAY_CONFIG_FILE} 2>1 &>/var/log/oasis-web3-gateway.log &
-    OASIS_WEB3_GATEWAY_PID=$!
+  notice "Starting oasis-web3-gateway...\n"
+  ${OASIS_WEB3_GATEWAY_BINARY} --config ${OASIS_WEB3_GATEWAY_CONFIG_FILE} 2>1 &>/var/log/oasis-web3-gateway.log &
+  OASIS_WEB3_GATEWAY_PID=$!
 fi
 
 # Wait for compute nodes before initiating deposit.
 notice "Bootstrapping network (this might take a minute)"
 if [[ "${BEACON_BACKEND}" == "mock" ]]; then
-    echo -n .
-    notice_debug -l "Waiting for nodes to be ready..."
-    ${OASIS_NODE_BINARY} debug control wait-nodes -n 2 -a unix:${OASIS_NODE_SOCKET}
+  echo -n .
+  notice_debug -l "Waiting for nodes to be ready..."
+  ${OASIS_NODE_BINARY} debug control wait-nodes -n 2 -a unix:${OASIS_NODE_SOCKET}
 
-    echo -n .
-    notice_debug -l "Setting epoch to 1..."
-    ${OASIS_NODE_BINARY} debug control set-epoch --epoch 1 -a unix:${OASIS_NODE_SOCKET}
+  echo -n .
+  notice_debug -l "Setting epoch to 1..."
+  ${OASIS_NODE_BINARY} debug control set-epoch --epoch 1 -a unix:${OASIS_NODE_SOCKET}
 
-    # Transition to the final epoch when the KM generates ephemeral secret.
-    if [[ "${PARATIME_NAME}" == "sapphire" ]]; then
-        notice_debug -l "Waiting for key manager to generate ephemeral secret..."
-        while (${OASIS_NODE_BINARY} control status -a unix:${OASIS_KM_SOCKET} | jq -e ".keymanager.secrets.worker.ephemeral_secrets.last_generated_epoch!=2" >/dev/null); do
-            sleep 0.5
-        done
-    fi
+  # Transition to the final epoch when the KM generates ephemeral secret.
+  if [[ "${PARATIME_NAME}" == "sapphire" ]]; then
+    notice_debug -l "Waiting for key manager to generate ephemeral secret..."
+    while (${OASIS_NODE_BINARY} control status -a unix:${OASIS_KM_SOCKET} | jq -e ".keymanager.secrets.worker.ephemeral_secrets.last_generated_epoch!=2" >/dev/null); do
+      sleep 0.5
+    done
+  fi
 
-    echo -n .
-    notice_debug -l "Setting epoch to 2..."
-    ${OASIS_NODE_BINARY} debug control set-epoch --epoch 2 -a unix:${OASIS_NODE_SOCKET}
+  echo -n .
+  notice_debug -l "Setting epoch to 2..."
+  ${OASIS_NODE_BINARY} debug control set-epoch --epoch 2 -a unix:${OASIS_NODE_SOCKET}
 else
-    echo -n ...
-    notice_debug -l "Waiting for nodes to be ready..."
-    ${OASIS_NODE_BINARY} debug control wait-ready -a unix:${OASIS_NODE_SOCKET}
+  echo -n ...
+  notice_debug -l "Waiting for nodes to be ready..."
+  ${OASIS_NODE_BINARY} debug control wait-ready -a unix:${OASIS_NODE_SOCKET}
 fi
 echo
 
 if [[ "x${OASIS_DOCKER_NO_GATEWAY}" != "xyes" && "${PARATIME_NAME}" == "sapphire" ]]; then
-    notice "Waiting for key manager..."
-    function is_km_ready() {
-        curl -X POST -s \
-          -H 'Content-Type: application/json' \
-          --data '{"jsonrpc":"2.0","method":"oasis_callDataPublicKey","params":[],"id":1}' \
-          http://127.0.0.1:8545 2>1 | jq -e '.result | has("key")' 2>1 &>/dev/null
-    }
-    until is_km_ready; do
-        if [[ "${BEACON_BACKEND}" == "mock" ]]; then
-            epoch=`${OASIS_NODE_BINARY} control status -a unix:${OASIS_NODE_SOCKET} | jq '.consensus.latest_epoch'`
-            epoch=$((epoch + 1))
-            ${OASIS_NODE_BINARY} debug control set-epoch --epoch $epoch -a unix:${OASIS_NODE_SOCKET}
-        fi
+  notice "Waiting for key manager..."
+  function is_km_ready() {
+    curl -X POST -s \
+      -H 'Content-Type: application/json' \
+      --data '{"jsonrpc":"2.0","method":"oasis_callDataPublicKey","params":[],"id":1}' \
+      http://127.0.0.1:8545 2>1 | jq -e '.result | has("key")' 2>1 &>/dev/null
+  }
+  until is_km_ready; do
+    if [[ "${BEACON_BACKEND}" == "mock" ]]; then
+      epoch=`${OASIS_NODE_BINARY} control status -a unix:${OASIS_NODE_SOCKET} | jq '.consensus.latest_epoch'`
+      epoch=$((epoch + 1))
+      ${OASIS_NODE_BINARY} debug control set-epoch --epoch $epoch -a unix:${OASIS_NODE_SOCKET}
+    fi
 
-        echo -n .
-        sleep 1
-    done
-    echo
+    echo -n .
+    sleep 1
+  done
+  echo
 else
-    # Wait a bit to ensure client is ready if we're not waiting for keymanager.
-    sleep 10
+  # Wait a bit to ensure client is ready if we're not waiting for keymanager.
+  sleep 10
 fi
 
 notice "Populating accounts...\n\n"
@@ -215,30 +215,30 @@ fi
 
 # Register ROFL and fund accounts.
 if [ ! -z "${ROFL_BINARY:-}" ]; then
-    # Since rofl.sgxs and MR_SIGNER never change, we can hardcode enclave identity.
-    # !/usr/bin/python
-    # import codecs
-    # mr_enclave = b'01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b' # sha256sum /rofl.sgxs
-    # mr_signer = b'9affcfae47b848ec2caf1c49b4b283531e1cc425f93582b36806e52a43d78d1a'  # hardcoded test MR_SIGNER
-    # codecs.encode(codecs.decode(mr_enclave + mr_signer, 'hex'), 'base64').decode().replace('\n', '')
-    ROFL_ENCLAVE_ID="0+tTmlVjUvP0eIHXH7Dld3svPppCUdKDwYxnzplndLea/8+uR7hI7CyvHEm0soNTHhzEJfk1grNoBuUqQ9eNGg=="
-    ROFL_ADMIN="test:bob"
-    ROFL_ADMIN_FUND=10001
-    COMPUTE_NODE_ADDRESS="oasis1qp6tl30ljsrrqnw2awxxu2mtxk0qxyy2nymtsy90"
-    COMPUTE_NODE_FUND=1000
-    POLICY_PATH=/policy-localnet.yml
+  # Since rofl.sgxs and MR_SIGNER never change, we can hardcode enclave identity.
+  # !/usr/bin/python
+  # import codecs
+  # mr_enclave = b'01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b' # sha256sum /rofl.sgxs
+  # mr_signer = b'9affcfae47b848ec2caf1c49b4b283531e1cc425f93582b36806e52a43d78d1a'  # hardcoded test MR_SIGNER
+  # codecs.encode(codecs.decode(mr_enclave + mr_signer, 'hex'), 'base64').decode().replace('\n', '')
+  ROFL_ENCLAVE_ID="0+tTmlVjUvP0eIHXH7Dld3svPppCUdKDwYxnzplndLea/8+uR7hI7CyvHEm0soNTHhzEJfk1grNoBuUqQ9eNGg=="
+  ROFL_ADMIN="test:bob"
+  ROFL_ADMIN_FUND=10001
+  COMPUTE_NODE_ADDRESS="oasis1qp6tl30ljsrrqnw2awxxu2mtxk0qxyy2nymtsy90"
+  COMPUTE_NODE_FUND=1000
+  POLICY_PATH=/policy-localnet.yml
 
-    echo
-    notice "Configuring ROFL ${ROFLS[0]}:\n"
-    printf "   Enclave ID ${CYAN}${ROFL_ENCLAVE_ID}${OFF}\n"
+  echo
+  notice "Configuring ROFL ${ROFLS[0]}:\n"
+  printf "   Enclave ID: ${CYAN}${ROFL_ENCLAVE_ID}${OFF}\n"
 
-    ${OASIS_CLI_BINARY} account deposit ${ROFL_ADMIN_FUND} ${ROFL_ADMIN} --account test:alice --gas-price 0 -y >/dev/null
-    printf "   ROFL admin ${CYAN}${ROFL_ADMIN}${OFF} funded ${ROFL_ADMIN_FUND} TEST\n"
+  ${OASIS_CLI_BINARY} account deposit ${ROFL_ADMIN_FUND} ${ROFL_ADMIN} --account test:alice --gas-price 0 -y >/dev/null
+  printf "   ROFL admin ${CYAN}${ROFL_ADMIN}${OFF} funded ${ROFL_ADMIN_FUND} TEST\n"
 
-    ${OASIS_CLI_BINARY} account deposit ${COMPUTE_NODE_FUND} ${COMPUTE_NODE_ADDRESS} --account test:alice --gas-price 0 -y >/dev/null
-    printf "   Compute node ${CYAN}${COMPUTE_NODE_ADDRESS}${OFF} funded ${COMPUTE_NODE_FUND} TEST\n"
+  ${OASIS_CLI_BINARY} account deposit ${COMPUTE_NODE_FUND} ${COMPUTE_NODE_ADDRESS} --account test:alice --gas-price 0 -y >/dev/null
+  printf "   Compute node ${CYAN}${COMPUTE_NODE_ADDRESS}${OFF} funded ${COMPUTE_NODE_FUND} TEST\n"
 
-    cat > ${POLICY_PATH} << EOF
+  cat > ${POLICY_PATH} << EOF
 quotes:
   pcs:
     tcb_validity_period: 30
@@ -250,9 +250,9 @@ endorsements:
 fees: endorsing_node
 max_expiration: 3
 EOF
-    # XXX: Report ROFL app ID in JSON and properly parse it.
-    ROFL_APP_ID=$(${OASIS_CLI_BINARY} rofl create ${POLICY_PATH} --account ${ROFL_ADMIN} --scheme cn -y | tail -n1 | rev | cut -d' ' -f1 | rev)
-    printf "   App ID ${CYAN}${ROFL_APP_ID}${OFF}\n"
+  # XXX: Report ROFL app ID in JSON and properly parse it.
+  ROFL_APP_ID=$(${OASIS_CLI_BINARY} rofl create ${POLICY_PATH} --account ${ROFL_ADMIN} --scheme cn -y | tail -n1 | rev | cut -d' ' -f1 | rev)
+  printf "   App ID: ${CYAN}${ROFL_APP_ID}${OFF}\n"
 fi
 
 echo
@@ -263,39 +263,39 @@ notice "Container start-up took ${CYAN}$((T_END-T_START))${OFF} seconds, node lo
 touch /CONTAINER_READY
 
 if [[ "x${OASIS_DOCKER_DEBUG_DISK_AND_CPU_USAGE}" == "xyes" ]]; then
-    # When debugging disk and CPU usage, we terminate the container
-    # after 60 minutes.
-    QUIT_AFTER_N_REPORTS=6
-    NUM_REPORTS=0
+  # When debugging disk and CPU usage, we terminate the container
+  # after 60 minutes.
+  QUIT_AFTER_N_REPORTS=6
+  NUM_REPORTS=0
 
-    # Also print a header for the readings below.
-    echo
-    echo "Uptime [minutes],Total node dir size [kB],Size of node logs [kB],Percent usage by logs [%],Load average (1 min),Load average (5 min),Load average (15 min)"
+  # Also print a header for the readings below.
+  echo
+  echo "Uptime [minutes],Total node dir size [kB],Size of node logs [kB],Percent usage by logs [%],Load average (1 min),Load average (5 min),Load average (15 min)"
 fi
 
 if [[ "${BEACON_BACKEND}" == "mock" ]]; then
-    # Run background task to switch epochs every 10 minutes.
-    while true; do
-        if [[ "x${OASIS_DOCKER_DEBUG_DISK_AND_CPU_USAGE}" == "xyes" ]]; then
-            LOADAVG=$(uptime | cut -d':' -f5 | tr -d ' ')
-            TOTAL_NODE_DIR_SIZE_KB=$(du -sk /serverdir/node | cut -f1)
-            TOTAL_NODE_LOGS_SIZE_KB=$(du -skc /serverdir/node/net-runner/network/*/*.log | tail -1 | cut -f1)
-            LOGS_PCT=$(echo "scale=4; (${TOTAL_NODE_LOGS_SIZE_KB} / ${TOTAL_NODE_DIR_SIZE_KB}) * 100" | bc)
+  # Run background task to switch epochs every 10 minutes.
+  while true; do
+    if [[ "x${OASIS_DOCKER_DEBUG_DISK_AND_CPU_USAGE}" == "xyes" ]]; then
+      LOADAVG=$(uptime | cut -d':' -f5 | tr -d ' ')
+      TOTAL_NODE_DIR_SIZE_KB=$(du -sk /serverdir/node | cut -f1)
+      TOTAL_NODE_LOGS_SIZE_KB=$(du -skc /serverdir/node/net-runner/network/*/*.log | tail -1 | cut -f1)
+      LOGS_PCT=$(echo "scale=4; (${TOTAL_NODE_LOGS_SIZE_KB} / ${TOTAL_NODE_DIR_SIZE_KB}) * 100" | bc)
 
-            echo "$((NUM_REPORTS * 10)),${TOTAL_NODE_DIR_SIZE_KB},${TOTAL_NODE_LOGS_SIZE_KB},${LOGS_PCT},${LOADAVG}"
+      echo "$((NUM_REPORTS * 10)),${TOTAL_NODE_DIR_SIZE_KB},${TOTAL_NODE_LOGS_SIZE_KB},${LOGS_PCT},${LOADAVG}"
 
-            if [[ ${NUM_REPORTS} -ge ${QUIT_AFTER_N_REPORTS} ]]; then
-                exit 0
-            fi
-            NUM_REPORTS=$((NUM_REPORTS + 1))
-        fi
+      if [[ ${NUM_REPORTS} -ge ${QUIT_AFTER_N_REPORTS} ]]; then
+        exit 0
+      fi
+      NUM_REPORTS=$((NUM_REPORTS + 1))
+    fi
 
-        sleep $((60*10))
+    sleep $((60*10))
 
-        epoch=`${OASIS_NODE_BINARY} control status -a unix:${OASIS_NODE_SOCKET} | jq '.consensus.latest_epoch'`
-        epoch=$((epoch + 1))
-        ${OASIS_NODE_BINARY} debug control set-epoch --epoch $epoch -a unix:${OASIS_NODE_SOCKET}
-    done
+    epoch=`${OASIS_NODE_BINARY} control status -a unix:${OASIS_NODE_SOCKET} | jq '.consensus.latest_epoch'`
+    epoch=$((epoch + 1))
+    ${OASIS_NODE_BINARY} debug control set-epoch --epoch $epoch -a unix:${OASIS_NODE_SOCKET}
+  done
 else
-    wait
+  wait
 fi

--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache bash gcompat libseccomp jq binutils \
 
 # Docker-specific variables
 ENV OASIS_CORE_VERSION=24.2
-ENV OASIS_CLI_VERSION=0.10.0
+ENV OASIS_CLI_VERSION=0.10.1
 ENV PARATIME_VERSION=11.0.0-testnet
 ENV PARATIME_NAME=emerald
 ENV GATEWAY__CHAIN_ID=0xa514
@@ -36,6 +36,9 @@ COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
 COPY docker/common/start.sh /
 COPY docker/common/wait-container-ready.sh /
 COPY tests/tools/* /
+
+# Create symbolic links for convenience.
+RUN ln -s ${OASIS_NODE_BINARY} ${OASIS_CLI_BINARY} /usr/local/bin
 
 # Configure oasis-node and oasis-net-runner.
 RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_CORE_VERSION}/oasis_core_${OASIS_CORE_VERSION}_linux_amd64.tar.gz"  \

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -35,7 +35,7 @@ RUN wget https://github.com/oasisprotocol/oasis-core/releases/download/v${OASIS_
 #    && mv /oasis-core/go/oasis-net-runner/oasis-net-runner /oasis-core/go/oasis-node/oasis-node / \
 #    && rm -rf /oasis-core
 
-ENV OASIS_CLI_VERSION=0.10.0
+ENV OASIS_CLI_VERSION=0.10.1
 RUN wget https://github.com/oasisprotocol/cli/releases/download/v${OASIS_CLI_VERSION}/oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz \
     && tar -zxvf oasis_cli_${OASIS_CLI_VERSION}_linux_amd64.tar.gz \
     && strip -S -x /oasis_cli_${OASIS_CLI_VERSION}_linux_amd64/oasis \
@@ -107,7 +107,7 @@ ENV OASIS_UNSAFE_MOCK_SGX=1
 
 ARG VERSION
 
-# Copy local builds.
+# Copy binaries.
 COPY --from=oasis-core-dev /simple-keymanager ${KEYMANAGER_BINARY}
 COPY --from=oasis-core-dev /oasis-deposit ${OASIS_DEPOSIT_BINARY}
 COPY --from=oasis-core-dev /oasis-web3-gateway ${OASIS_WEB3_GATEWAY_BINARY}
@@ -116,10 +116,15 @@ COPY --from=oasis-core-dev /oasis-net-runner ${OASIS_NET_RUNNER_BINARY}
 COPY --from=oasis-core-dev /oasis ${OASIS_CLI_BINARY}
 COPY --from=oasis-core-dev /sapphire-paratime ${PARATIME_BINARY}
 
+# Create symbolic links for convenience.
+RUN ln -s ${OASIS_NODE_BINARY} ${OASIS_CLI_BINARY} /usr/local/bin
+
 COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
 COPY docker/common/start.sh /
 COPY docker/common/wait-container-ready.sh /
 COPY tests/tools/* /
+
+RUN mkdir /rofls
 
 # Configure paratime.
 RUN echo "Write VERSION information." \

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -118,4 +118,4 @@ jq ".runtimes[${RT_IDX}].txn_scheduler.batch_flush_timeout=1000000000" "$FIXTURE
 mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 
 # Run oasis-node.
-${OASIS_NET_RUNNER_BINARY} --fixture.file "$FIXTURE_FILE" --basedir "${OASIS_NODE_DATADIR}" --basedir.no_temp_dir $@
+${OASIS_NET_RUNNER_BINARY} --fixture.file "$FIXTURE_FILE" --basedir "${OASIS_NODE_DATADIR}" --basedir.no_temp_dir --log.format JSON $@

--- a/tests/tools/spinup-oasis-stack.sh
+++ b/tests/tools/spinup-oasis-stack.sh
@@ -6,12 +6,14 @@ set -euo pipefail
 # Supported ENV Variables:
 # - OASIS_NODE_BINARY: path to oasis-node binary
 # - OASIS_NET_RUNNER_BINARY: path to oasis-net-runner binary
-# - BEACON_BACKEND: choose 'mock' backend (default), or use other behavior
+# - BEACON_BACKEND (optional): choose 'mock' backend (default), or use other behavior
 # - PARATIME_BINARY: path to ParaTime binary (inside .orc bundle)
 # - PARATIME_VERSION: version of the binary. e.g. 3.0.0
+# - ROFL_BINARY (optional): path to ROFL binary (inside .orc bundle)
+# - ROFL_BINARY_SGXS (optional): path to signed ROFL binary (inside .orc bundle)
 # - OASIS_NODE_DATADIR: path to temporary oasis-node data dir e.g. /tmp/oasis-localnet
-# - KEYMANAGER_BINARY: path to key manager binary e.g. simple-keymanager
-# - OASIS_SINGLE_COMPUTE_NODE: Only run a single compute node
+# - KEYMANAGER_BINARY (optional): path to key manager binary e.g. simple-keymanager
+# - OASIS_SINGLE_COMPUTE_NODE (optional): Only run a single compute node
 
 function paratime_ver {
   echo $PARATIME_VERSION | cut -d \- -f 1 | cut -d + -f 1 | cut -d . -f $1
@@ -57,6 +59,16 @@ if [ ! -z "${KEYMANAGER_BINARY:-}" ]; then
     .runtimes[0].deployments[0].components[0].binaries.\"0\" = \"${KEYMANAGER_BINARY}\" |
     .runtimes[${RT_IDX}].deployments[0].components[0].binaries.\"0\" = \"${PARATIME_BINARY}\"
   " "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
+  mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
+fi
+
+# Register a ROFL binary, if it exists.
+if [ ! -z "${ROFL_BINARY:-}" ] && [ ! -z "${ROFL_BINARY_SGXS:-}" ]; then
+  jq "
+      .runtimes[${RT_IDX}].deployments[0].components[1].kind = \"rofl\" |
+      .runtimes[${RT_IDX}].deployments[0].components[1].binaries.\"0\" = \"${ROFL_BINARY}\" |
+      .runtimes[${RT_IDX}].deployments[0].components[1].binaries.\"1\" = \"${ROFL_BINARY_SGXS}\"
+    " "$FIXTURE_FILE" >"$FIXTURE_FILE.tmp"
   mv "$FIXTURE_FILE.tmp" "$FIXTURE_FILE"
 fi
 


### PR DESCRIPTION
This PR:
- adds support for starting ROFLS within the sapphire-localnet including supprot for fixtures, ROFL registration and funding the admin and the node accounts
- enables oasis-node -test-mnemonic by default
- configures Localnet for Oasis CLI and sets it as default

Fixes https://github.com/oasisprotocol/oasis-web3-gateway/issues/603, #613 

To start your ROFL, simply bind mount your folder containing the .orc file to the `/rofls` folder and it will spin it up automatically.

For example:

```
$ docker run -it -p8545:8545 -p8546:8546 -v /home/oa/rofl-oracle:/rofls ghcr.io/oasisprotocol/sapphire-localnet:local 
sapphire-localnet local (oasis-core: 24.2, sapphire-paratime: 0.8.2-testnet, oasis-web3-gateway: 5.1.0)

 * Detected ROFL bundle: /rofls/rofl-oracle.orc
 * Starting oasis-net-runner with sapphire...
 * Waiting for Postgres to start.....
 * Waiting for Oasis node to start....
 * Starting oasis-web3-gateway...
 * Bootstrapping network (this might take a minute).
 * Waiting for nodes to be ready....
 * Setting epoch to 1...
 * Waiting for key manager to generate ephemeral secret....
 * Setting epoch to 2...
 * Waiting for key manager......
 * Populating accounts...

Available Accounts
==================
(0) 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 (10000 TEST)
(1) 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 (10000 TEST)
(2) 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC (10000 TEST)
(3) 0x90F79bf6EB2c4f870365E785982E1f101E93b906 (10000 TEST)
(4) 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65 (10000 TEST)

Private Keys
==================
(0) 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
(1) 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
(2) 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
(3) 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6
(4) 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a

HD Wallet
==================
Mnemonic:       test test test test test test test test test test test junk
Base HD Path:   m/44'/60'/0'/0/%d

 * Configuring ROFL /rofls/rofl-oracle.orc:
   Enclave ID 0+tTmlVjUvP0eIHXH7Dld3svPppCUdKDwYxnzplndLea/8+uR7hI7CyvHEm0soNTHhzEJfk1grNoBuUqQ9eNGg==
   ROFL admin test:bob funded 10001 TEST
   Compute node oasis1qp6tl30ljsrrqnw2awxxu2mtxk0qxyy2nymtsy90 funded 1000 TEST
   App ID rofl1qqn9xndja7e2pnxhttktmecvwzz0yqwxsquqyxdf

WARNING: The chain is running in ephemeral mode. State will be lost after restart!

 * Listening on http://localhost:8545 and ws://localhost:8546. Chain ID: 0x5afd
 * Container start-up took 66 seconds, node log level is set to warn.
```