### PR TITLE
docker/sapphire: Include Envoy proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the full gateway & paratime stack together.
 For running tests, start the docker network without the gateway, by setting the `OASIS_DOCKER_NO_GATEWAY=yes` environment variable:
 
 ```bash
-docker run --rm -ti -e OASIS_DOCKER_NO_GATEWAY=yes -p5432:5432 -p8545:8545 -p8546:8546 -v /tmp/eth-runtime-test:/serverdir/node ghcr.io/oasisprotocol/sapphire-localnet:local -test-mnemonic -n 4
+docker run --rm -ti -e OASIS_DOCKER_NO_GATEWAY=yes -p5432:5432 -p8544-8546:8544-8546 -v /tmp/eth-runtime-test:/serverdir/node ghcr.io/oasisprotocol/sapphire-localnet:local -test-mnemonic -n 4
 ```
 
 Once bootstrapped, run the tests:

--- a/docker/common/envoy.yml
+++ b/docker/common/envoy.yml
@@ -1,0 +1,80 @@
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        address: "0.0.0.0"
+        port_value: 8544
+    filter_chains:
+      - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              codec_type: AUTO
+              stat_prefix: ingress_http
+              access_log:
+                - name: envoy.file_access_log
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    path: /var/log/envoy_access.log
+              route_config:
+                virtual_hosts:
+                  - name: client0
+                    domains: ['*']
+                    routes:
+                      - match:
+                          safe_regex:
+                            # Allow all oasis-core methods.
+                            regex: '^/oasis-core\..*'
+                        route:
+                          cluster: client_0_grpc
+                          timeout: 0s
+                          max_stream_duration:
+                            grpc_timeout_header_max: 0s
+                      - match:
+                          prefix: ''
+                        direct_response:
+                          status: 404
+                          body:
+                            inline_string: Invalid method.
+                    typed_per_filter_config:
+                      envoy.filters.http.cors:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                        expose_headers: grpc-status,grpc-message,grpc-status-details-bin
+                        allow_origin_string_match:
+                          - exact: '*'
+                        allow_headers: content-type,x-grpc-web,x-user-agent
+                        max_age: '1728000'
+              http_filters:
+                - name: envoy.filters.http.grpc_web
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                - name: envoy.filters.http.cors
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                - name: envoy.filters.http.router
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: client_0_grpc
+    connect_timeout: 0.25s
+    load_assignment:
+      cluster_name: cluster_0
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              pipe:
+                path: /serverdir/node/net-runner/network/client-0/internal.sock
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+layered_runtime:
+  layers:
+  - name: static
+    static_layer:
+      re2:
+        max_program_size:
+          error_level: 1000000

--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -5,9 +5,19 @@ COPY . /go/oasis-web3-gateway
 RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway docker/common/oasis-deposit/oasis-deposit
 
 # Build emerald-localnet
-FROM postgres:16-alpine
-RUN apk add --no-cache bash gcompat libseccomp jq binutils \
-	&& su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
+FROM postgres:16-bookworm
+RUN apt update && apt install -y bash libseccomp2 unzip jq binutils curl wget && apt clean \
+    && su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres \
+    # Install Envoy.
+    && curl -fsSL https://apt.envoyproxy.io/signing.key | gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bookworm main" | tee /etc/apt/sources.list.d/envoy.list \
+    && apt update \
+    && apt install -y envoy \
+    # Clean up.
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm -rf /etc/apt/sources.list.d/envoy.list \
+    && rm -f /etc/apt/keyrings/envoy-keyring.gpg
 
 # Docker-specific variables
 ENV OASIS_CORE_VERSION=24.2
@@ -23,6 +33,8 @@ ENV OASIS_NODE_DATADIR=/serverdir/node
 ENV OASIS_WEB3_GATEWAY_BINARY=/oasis-web3-gateway
 ENV OASIS_DEPOSIT_BINARY=/oasis-deposit
 ENV OASIS_WEB3_GATEWAY_CONFIG_FILE=/localnet.yml
+ENV ENVOY_BINARY=/usr/bin/envoy
+ENV ENVOY_CONFIG_FILE=/envoy.yml
 ENV PARATIME_BINARY=/runtime.elf
 ENV KEYMANAGER_BINARY=""
 ENV OASIS_CLI_BINARY=/oasis
@@ -33,6 +45,7 @@ ARG VERSION
 COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/oasis-web3-gateway ${OASIS_WEB3_GATEWAY_BINARY}
 COPY --from=oasis-web3-gateway /go/oasis-web3-gateway/docker/common/oasis-deposit/oasis-deposit ${OASIS_DEPOSIT_BINARY}
 COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
+COPY docker/common/envoy.yml ${ENVOY_CONFIG_FILE}
 COPY docker/common/start.sh /
 COPY docker/common/wait-container-ready.sh /
 COPY tests/tools/* /
@@ -67,6 +80,8 @@ RUN wget --quiet "https://github.com/oasisprotocol/oasis-core/releases/download/
 	&& echo "${VERSION}" > /VERSION \
 	&& strip -S -x ${OASIS_NET_RUNNER_BINARY} ${OASIS_NODE_BINARY} ${OASIS_CLI_BINARY}
 
+# Envoy proxy port.
+EXPOSE 8544/tcp
 # Web3 gateway http and ws ports.
 EXPOSE 8545/tcp
 EXPOSE 8546/tcp

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -79,13 +79,19 @@ RUN wget https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/dow
 #    && rm -rf sapphire-paratime-git
 
 # Build sapphire-localnet
-#FROM postgres:16-alpine
-#RUN apk add --no-cache bash gcompat libseccomp jq binutils curl \
-#    && su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
-# Fallback to Debian-based image. See https://github.com/oasisprotocol/oasis-web3-gateway/issues/622
-FROM postgres:16
+FROM postgres:16-bookworm
 RUN apt update && apt install -y bash libseccomp2 unzip jq binutils curl && apt clean \
-    && su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres
+    && su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres \
+    # Install Envoy.
+    && curl -fsSL https://apt.envoyproxy.io/signing.key | gpg --dearmor -o /etc/apt/keyrings/envoy-keyring.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/envoy-keyring.gpg] https://apt.envoyproxy.io bookworm main" | tee /etc/apt/sources.list.d/envoy.list \
+    && apt update \
+    && apt install -y envoy \
+    # Clean up.
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm -rf /etc/apt/sources.list.d/envoy.list \
+    && rm -f /etc/apt/keyrings/envoy-keyring.gpg
 
 # Docker-specific variables
 ARG PARATIME_VERSION
@@ -100,6 +106,8 @@ ENV OASIS_NODE_BINARY=/oasis-node
 ENV OASIS_NET_RUNNER_BINARY=/oasis-net-runner
 ENV OASIS_NODE_DATADIR=/serverdir/node
 ENV OASIS_WEB3_GATEWAY_BINARY=/oasis-web3-gateway
+ENV ENVOY_BINARY=/usr/bin/envoy
+ENV ENVOY_CONFIG_FILE=/envoy.yml
 ENV OASIS_DEPOSIT_BINARY=/oasis-deposit
 ENV OASIS_WEB3_GATEWAY_CONFIG_FILE=/localnet.yml
 ENV PARATIME_BINARY=/ronl.elf
@@ -124,6 +132,7 @@ COPY --from=oasis-core-dev /sapphire-paratime ${PARATIME_BINARY}
 RUN ln -s ${OASIS_NODE_BINARY} ${OASIS_CLI_BINARY} /usr/local/bin
 
 COPY docker/common/localnet.yml ${OASIS_WEB3_GATEWAY_CONFIG_FILE}
+COPY docker/common/envoy.yml ${ENVOY_CONFIG_FILE}
 COPY docker/common/start.sh /
 COPY docker/common/wait-container-ready.sh /
 COPY tests/tools/* /
@@ -143,6 +152,8 @@ RUN echo "Write VERSION information." \
     && ${OASIS_CLI_BINARY} --version \
     && echo
 
+# Envoy proxy port.
+EXPOSE 8544/tcp
 # Web3 gateway http and ws ports.
 EXPOSE 8545/tcp
 EXPOSE 8546/tcp


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-web3-gateway/issues/423

Envoy proxy is now included which exposes the clients node `internal.sock` on port `8544` (by default). Envoy is used because it also supports grpc-web, which might be useful/needed when testing any dapps.