### PR TITLE
fix occasional stuck localnet bootstrap

### DIFF
--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -172,6 +172,16 @@ if [[ "${BEACON_BACKEND}" == "mock" ]]; then
   notice_debug -l "Waiting for nodes to be ready..."
   ${OASIS_NODE_BINARY} debug control wait-nodes -n 2 -a unix:${OASIS_NODE_SOCKET}
 
+  if [[ "${PARATIME_NAME}" == "sapphire" ]]; then
+    echo -n .
+    # The key manager registers before it is fully ready, so the previous 'wait-nodes' check is not sufficient.
+    # Ensure the key manager is fully ready before moving to the first epoch.
+    notice_debug -l "Waiting for key manager to start up..."
+    while (${OASIS_NODE_BINARY} control status -a unix:${OASIS_KM_SOCKET} | jq -e '.keymanager.status!="ready"' >/dev/null); do
+      sleep 0.5
+    done
+  fi
+
   echo -n .
   notice_debug -l "Setting epoch to 1..."
   ${OASIS_NODE_BINARY} debug control set-epoch --epoch 1 -a unix:${OASIS_NODE_SOCKET}


### PR DESCRIPTION
For me, quite often, the local net setup when using the mock epoch backend got stuck in the bootstrapping part due to the key manager not being in the KM committee after the transition to the first epoch and was unable to generate the master secret.

```
{"caller":"secrets.go:779","err":"node not in the key manager committee","level":"error","module":"worker/keymanager/secrets","msg":"failed to generate master secret","retry":5,"ts":"2024-10-18T10:02:27.763288958Z"}
```

Interestingly, even just enabling the debug logs (via `OASIS_NODE_LOG_LEVEL=debug`) slowed things down enough never to hit the issue so the delay needs to be really minimal.

---

Ensure that the key manager is ready before transitioning to the next epoch. In practice this introduces a 0.5-1 sec delay to the startup, since in the first `control status` query the keymanager is usually in the `starting` state, and by the second iteration the keymanager is usually `ready`.