### PR TITLE
feat: report just the number of logs matched in debug logs for `eth_getLogs`

### DIFF
--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -682,7 +682,7 @@ func (api *publicAPI) GetLogs(ctx context.Context, filter filters.FilterCriteria
 
 	// Early return if no further filtering.
 	if len(filter.Addresses) == 0 && len(filter.Topics) == 0 {
-		logger.Debug("response", "rsp", ethLogs)
+		logger.Debug("response", "num_logs", len(ethLogs))
 		return ethLogs, nil
 	}
 
@@ -709,7 +709,7 @@ func (api *publicAPI) GetLogs(ctx context.Context, filter filters.FilterCriteria
 		filtered = append(filtered, log)
 	}
 
-	logger.Debug("response", "rsp", filtered, "all_logs", ethLogs)
+	logger.Debug("response", "num_logs", len(filtered), "all_logs", ethLogs)
 	return filtered, nil
 }
 


### PR DESCRIPTION
Reduce verbosity of `eth_getLogs` debug logs: instead of logging full responses, only log the number of logs matched. Previously, we logged all logs in the queried range which really bloated the debug log output of the web3 gateway.

For debugging purposes, full responses can still be obtained by re-running the query, as the query itself is logged.