### PR TITLE
internal(goreleaser): snapshot.name_template renamed

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,7 +34,7 @@ git:
   tag_sort: '-version:creatordate'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
https://goreleaser.com/deprecations/#snapshotname_template