### PR TITLE
feat: use the built-in max/min to simplify the code

### DIFF
--- a/db/migrations/20220109122505_logs.up.go
+++ b/db/migrations/20220109122505_logs.up.go
@@ -165,10 +165,7 @@ func LogsUp(ctx context.Context, tx *bun.Tx) error {
 
 	for i := start; i <= end; i += batchSize {
 		bs := i
-		be := i + batchSize - 1
-		if be > end {
-			be = end
-		}
+		be := min(i+batchSize-1, end)
 
 		logger.Debug("migrating batch", "batch_start", bs, "batch_end", be)
 		// Fetch all logs for the batch rounds.

--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -185,11 +185,7 @@ func (api *publicAPI) roundParamFromBlockNum(ctx context.Context, logger *loggin
 			logger.Error("failed to get last retained block from indexer", "err", err)
 			return 0, ErrInternalError
 		}
-		if clrBlk.Header.Round < ilrRound {
-			earliest = ilrRound
-		} else {
-			earliest = clrBlk.Header.Round
-		}
+		earliest = max(clrBlk.Header.Round, ilrRound)
 		return earliest, nil
 	default:
 		if int64(blockNum) < 0 {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.