### PR TITLE
feat: eth_getStorageAt standard empty response

### DIFF
--- a/archive/client.go
+++ b/archive/client.go
@@ -32,23 +32,20 @@ func (c *Client) LatestBlock() uint64 {
 func (c *Client) GetStorageAt(
 	ctx context.Context,
 	address common.Address,
-	position hexutil.Big,
+	slot common.Hash,
 	blockNr uint64,
-) (hexutil.Big, error) {
+) (hexutil.Bytes, error) {
 	storageBytes, err := c.inner.StorageAt(
 		ctx,
 		address,
-		common.BigToHash((*big.Int)(&position)),
+		slot,
 		new(big.Int).SetUint64(blockNr),
 	)
 	if err != nil {
-		return hexutil.Big{}, fmt.Errorf("archive: failed to query storage: %w", err)
+		return nil, fmt.Errorf("archive: failed to query storage: %w", err)
 	}
 
-	// Oh for fuck's sake.
-	var storageBig big.Int
-	storageBig.SetBytes(storageBytes)
-	return hexutil.Big(storageBig), nil
+	return storageBytes, nil
 }
 
 func (c *Client) GetBalance(

--- a/rpc/eth/metrics/api.go
+++ b/rpc/eth/metrics/api.go
@@ -286,11 +286,11 @@ func (m *metricsWrapper) GetLogs(ctx context.Context, filter filters.FilterCrite
 }
 
 // GetStorageAt implements eth.API.
-func (m *metricsWrapper) GetStorageAt(ctx context.Context, address common.Address, position hexutil.Big, blockNrOrHash ethrpc.BlockNumberOrHash) (res hexutil.Big, err error) {
+func (m *metricsWrapper) GetStorageAt(ctx context.Context, address common.Address, slot string, blockNrOrHash ethrpc.BlockNumberOrHash) (res hexutil.Bytes, err error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_getStorageAt")
 	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
 
-	res, err = m.api.GetStorageAt(ctx, address, position, blockNrOrHash)
+	res, err = m.api.GetStorageAt(ctx, address, slot, blockNrOrHash)
 	return
 }
 


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-web3-gateway/issues/595

As seen in the referenced issues, a large majority of modern clients expect leading zeroes in the getStorageAt response.