### PR TITLE
feat: use slices.Sort where appropriate

### DIFF
--- a/indexer/backend_cache.go
+++ b/indexer/backend_cache.go
@@ -3,7 +3,7 @@ package indexer
 import (
 	"context"
 	"errors"
-	"sort"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -147,9 +147,7 @@ func (cb *cachingBackend) OnBlockIndexed(
 			rounds = append(rounds, key.(uint64))
 			return true
 		})
-		sort.Slice(rounds, func(i, j int) bool {
-			return rounds[i] < rounds[j]
-		})
+		slices.Sort(rounds)
 		for _, idx := range rounds {
 			cb.pruneCache(idx)
 			if cb.cacheSize <= cb.maxCacheSize {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.