### PR TITLE
fix: Logs index off by 1

### DIFF
--- a/indexer/utils.go
+++ b/indexer/utils.go
@@ -383,7 +383,7 @@ func (ib *indexBackend) StoreBlockData(ctx context.Context, oasisBlock *block.Bl
 				// Ignore any other events.
 			}
 		}
-		logs = append(logs, Logs2EthLogs(oasisLogs, blockNum, bhash, ethTx.Hash(), uint(len(logs)), uint32(len(ethTxs)))...)
+		logs = append(logs, Logs2EthLogs(oasisLogs, blockNum, bhash, ethTx.Hash(), uint(len(logs)), uint32(len(ethTxs)-1))...)
 
 		// Emerald GasUsed events were added in version 7.0.0.
 		// Default to using gas limit, which was the behaviour before.


### PR DESCRIPTION
Already indexed blocks will be fixed with the existing log fixer worker (added in https://github.com/oasisprotocol/oasis-web3-gateway/pull/787)