### PR TITLE
docker: Bump Oasis Core to 25.5 and CLI to 0.16.0 for sapphire-localnet

### DIFF
--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.25.0 AS oasis-web3-gateway
 COPY . /go/oasis-web3-gateway
 RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway
 
-FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.2.x AS oasis-core-dev
+FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.5.x AS oasis-core-dev
 
 ARG NEXUS_VERSION=0.6.13
 RUN wget https://github.com/oasisprotocol/nexus/releases/download/v${NEXUS_VERSION}/oasis_nexus_${NEXUS_VERSION}_linux_amd64.tar.gz \
@@ -46,7 +46,7 @@ RUN git clone ${EXPLORER_REPO} explorer --depth 1 \
 
 
 # Build emerald-localnet
-FROM postgres:16-bookworm
+FROM docker.io/postgres:16-bookworm
 RUN apt update && apt install -y bash libseccomp2 unzip jq binutils curl wget nginx && apt clean \
     && su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres \
 	# Explorer frontend deps.
@@ -63,8 +63,8 @@ RUN apt update && apt install -y bash libseccomp2 unzip jq binutils curl wget ng
     && rm -f /etc/apt/keyrings/envoy-keyring.gpg
 
 # Docker-specific variables
-ENV OASIS_CORE_VERSION=25.3
-ENV OASIS_CLI_VERSION=0.13.4
+ENV OASIS_CORE_VERSION=25.5
+ENV OASIS_CLI_VERSION=0.16.0
 ENV PARATIME_VERSION=11.0.0-testnet
 ENV PARATIME_NAME=emerald
 ENV GATEWAY__CHAIN_ID=0xa514

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -1,7 +1,7 @@
 ARG PARATIME_VERSION=1.0.0-testnet
 ARG PARATIME_NAME=sapphire
 
-FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.4.x AS oasis-core-dev
+FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.5.x AS oasis-core-dev
 
 ARG PARATIME_VERSION
 ARG PARATIME_NAME
@@ -11,10 +11,10 @@ ARG PARATIME_NAME
 # variant.
 # Note that the simple keymanager is always freshly built because we need to
 # specify different build options from what is in the release version.
-ARG OASIS_CORE_SIMPLE_KM_BRANCH=stable/25.4.x
-ARG OASIS_CORE_VERSION=25.4
+ARG OASIS_CORE_SIMPLE_KM_BRANCH=stable/25.5.x
+ARG OASIS_CORE_VERSION=25.5
 #ARG OASIS_CORE_BRANCH=stable/24.3.x
-ARG OASIS_CLI_VERSION=0.14.2
+ARG OASIS_CLI_VERSION=0.16.0
 #ARG OASIS_CLI_BRANCH=master
 ARG OASIS_WEB3_GATEWAY_BRANCH=v5.3.0
 #ARG OASIS_WEB3_GATEWAY_VERSION=main
@@ -154,7 +154,7 @@ RUN set -e; \
 
 
 # Build sapphire-localnet
-FROM postgres:16-bookworm
+FROM docker.io/postgres:16-bookworm
 
 # Docker-specific variables.
 ARG PARATIME_VERSION


### PR DESCRIPTION
This matches current Mainnet parameters.
Also changes postgres to docker.io/postgres so the images are buildable under podman.