### PR TITLE
other: replace interface{} with any for clarity and modernization

### DIFF
--- a/db/migrations/20220109122505_logs.up.go
+++ b/db/migrations/20220109122505_logs.up.go
@@ -128,7 +128,7 @@ func (s *Storage) InsertLogs(ctx context.Context, values []*Log) error {
 }
 
 // Upsert upserts a value.
-func (s *Storage) Upsert(ctx context.Context, value interface{}) error {
+func (s *Storage) Upsert(ctx context.Context, value any) error {
 	typ := reflect.TypeOf(value)
 	table := s.DB.Dialect().Tables().Get(typ)
 	pks := make([]string, len(table.PKs))

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -34,7 +34,7 @@ func DropTables(ctx context.Context, db *bun.DB) error {
 		return err
 	}
 
-	var results []map[string]interface{}
+	var results []map[string]any
 	if err = db.ScanRows(ctx, rows, &results); err != nil {
 		return err
 	}

--- a/indexer/backend.go
+++ b/indexer/backend.go
@@ -63,7 +63,7 @@ type GetEthInfoBackend interface {
 	GetBlockTransactionCountByRound(ctx context.Context, round uint64) (int, error)
 	GetBlockTransactionCountByHash(ctx context.Context, blockHash ethcommon.Hash) (int, error)
 	GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash ethcommon.Hash, txIndex int) (*model.Transaction, error)
-	GetTransactionReceipt(ctx context.Context, txHash ethcommon.Hash) (map[string]interface{}, error)
+	GetTransactionReceipt(ctx context.Context, txHash ethcommon.Hash) (map[string]any, error)
 	BlockNumber(ctx context.Context) (uint64, error)
 	GetLogs(ctx context.Context, startRound, endRound uint64) ([]*model.Log, error)
 }
@@ -320,7 +320,7 @@ func (ib *indexBackend) GetTransactionByBlockHashAndIndex(ctx context.Context, b
 }
 
 // GetTransactionReceipt returns the receipt for the given tx.
-func (ib *indexBackend) GetTransactionReceipt(ctx context.Context, txHash ethcommon.Hash) (map[string]interface{}, error) {
+func (ib *indexBackend) GetTransactionReceipt(ctx context.Context, txHash ethcommon.Hash) (map[string]any, error) {
 	dbReceipt, err := ib.storage.GetTransactionReceipt(ctx, txHash.String())
 	if err != nil {
 		return nil, err

--- a/indexer/backend_cache.go
+++ b/indexer/backend_cache.go
@@ -143,7 +143,7 @@ func (cb *CachingBackend) OnBlockIndexed(
 		// need to be all that large to service the vast majority of
 		// requests.
 		rounds := make([]uint64, 0, cb.cacheSize)
-		cb.blockDataByNumber.Range(func(key, _ interface{}) bool {
+		cb.blockDataByNumber.Range(func(key, _ any) bool {
 			rounds = append(rounds, key.(uint64))
 			return true
 		})
@@ -346,7 +346,7 @@ func (cb *CachingBackend) GetTransactionByBlockHashAndIndex(
 func (cb *CachingBackend) GetTransactionReceipt(
 	ctx context.Context,
 	txHash ethcommon.Hash,
-) (map[string]interface{}, error) {
+) (map[string]any, error) {
 	if receipt, ok := cb.cachedReceiptByTxHash(txHash); ok {
 		return db2EthReceipt(receipt), nil
 	}

--- a/indexer/utils.go
+++ b/indexer/utils.go
@@ -547,7 +547,7 @@ func (ib *indexBackend) StoreBlockData(ctx context.Context, oasisBlock *block.Bl
 }
 
 // db2EthReceipt converts model.Receipt to the GetTransactionReceipt format.
-func db2EthReceipt(dbReceipt *model.Receipt) map[string]interface{} {
+func db2EthReceipt(dbReceipt *model.Receipt) map[string]any {
 	ethLogs := make([]*ethtypes.Log, 0, len(dbReceipt.Logs))
 	for _, dbLog := range dbReceipt.Logs {
 		topics := make([]common.Hash, 0, len(dbLog.Topics))
@@ -573,7 +573,7 @@ func db2EthReceipt(dbReceipt *model.Receipt) map[string]interface{} {
 	}
 
 	effectiveGasPrice, _ := new(big.Int).SetString(dbReceipt.EffectiveGasPrice, 10)
-	receipt := map[string]interface{}{
+	receipt := map[string]any{
 		"status":            hexutil.Uint(dbReceipt.Status),
 		"cumulativeGasUsed": hexutil.Uint64(dbReceipt.CumulativeGasUsed),
 		"logsBloom":         ethtypes.BytesToBloom(logsBloom(ethLogs)),

--- a/main.go
+++ b/main.go
@@ -72,8 +72,8 @@ var (
 )
 
 func initVersions() {
-	cobra.AddTemplateFunc("toolchain", func() interface{} { return version.Toolchain })
-	cobra.AddTemplateFunc("sdk", func() interface{} { return version.GetOasisSDKVersion() })
+	cobra.AddTemplateFunc("toolchain", func() any { return version.Toolchain })
+	cobra.AddTemplateFunc("sdk", func() any { return version.GetOasisSDKVersion() })
 
 	rootCmd.SetVersionTemplate(`Software version: {{.Version}}
 Oasis SDK version: {{ sdk }}

--- a/rpc/eth/api.go
+++ b/rpc/eth/api.go
@@ -54,7 +54,7 @@ var (
 // API is the eth_ prefixed set of APIs in the Web3 JSON-RPC spec.
 type API interface {
 	// GetBlockByNumber returns the block identified by number.
-	GetBlockByNumber(ctx context.Context, blockNum ethrpc.BlockNumber, fullTx bool) (map[string]interface{}, error)
+	GetBlockByNumber(ctx context.Context, blockNum ethrpc.BlockNumber, fullTx bool) (map[string]any, error)
 	// GetBlockTransactionCountByNumber returns the number of transactions in the block.
 	GetBlockTransactionCountByNumber(ctx context.Context, blockNum ethrpc.BlockNumber) (hexutil.Uint, error)
 	// GetStorageAt returns the storage value at the provided position.
@@ -82,7 +82,7 @@ type API interface {
 	// EstimateGas returns an estimate of gas usage for the given transaction.
 	EstimateGas(ctx context.Context, args utils.TransactionArgs, blockNum *ethrpc.BlockNumber) (hexutil.Uint64, error)
 	// GetBlockByHash returns the block identified by hash.
-	GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (map[string]interface{}, error)
+	GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (map[string]any, error)
 	// GetTransactionByHash returns the transaction identified by hash.
 	GetTransactionByHash(ctx context.Context, hash common.Hash) (*utils.RPCTransaction, error)
 	// GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
@@ -90,7 +90,7 @@ type API interface {
 	// GetTransactionByBlockNumberAndIndex returns the transaction identified by number and index.
 	GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNum ethrpc.BlockNumber, index hexutil.Uint) (*utils.RPCTransaction, error)
 	// GetTransactionReceipt returns the transaction receipt by hash.
-	GetTransactionReceipt(ctx context.Context, txHash common.Hash) (map[string]interface{}, error)
+	GetTransactionReceipt(ctx context.Context, txHash common.Hash) (map[string]any, error)
 	// GetLogs returns the ethereum logs.
 	GetLogs(ctx context.Context, filter filters.FilterCriteria) ([]*ethtypes.Log, error)
 	// GetBlockHash returns the block hash by the given number.
@@ -105,7 +105,7 @@ type API interface {
 	Hashrate() hexutil.Uint64
 	// Syncing returns false in case the node is currently not syncing with the network, otherwise
 	// returns syncing information.
-	Syncing(ctx context.Context) (interface{}, error)
+	Syncing(ctx context.Context) (any, error)
 }
 
 type publicAPI struct {
@@ -195,7 +195,7 @@ func (api *publicAPI) roundParamFromBlockNum(ctx context.Context, logger *loggin
 	}
 }
 
-func (api *publicAPI) GetBlockByNumber(ctx context.Context, blockNum ethrpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
+func (api *publicAPI) GetBlockByNumber(ctx context.Context, blockNum ethrpc.BlockNumber, fullTx bool) (map[string]any, error) {
 	logger := api.Logger.With("method", "eth_getBlockByNumber", "block_number", blockNum, "full_tx", fullTx)
 	logger.Debug("request")
 
@@ -542,7 +542,7 @@ func (api *publicAPI) EstimateGas(ctx context.Context, args utils.TransactionArg
 	return hexutil.Uint64(gas), nil
 }
 
-func (api *publicAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (map[string]interface{}, error) {
+func (api *publicAPI) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (map[string]any, error) {
 	logger := api.Logger.With("method", "eth_getBlockByHash", "block_hash", blockHash, "full_tx", fullTx)
 	logger.Debug("request")
 
@@ -598,7 +598,7 @@ func (api *publicAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, b
 	return api.GetTransactionByBlockHashAndIndex(ctx, blockHash, index)
 }
 
-func (api *publicAPI) GetTransactionReceipt(ctx context.Context, txHash common.Hash) (map[string]interface{}, error) {
+func (api *publicAPI) GetTransactionReceipt(ctx context.Context, txHash common.Hash) (map[string]any, error) {
 	logger := api.Logger.With("method", "eth_getTransactionReceipt", "hash", txHash)
 	logger.Debug("request")
 
@@ -769,7 +769,7 @@ func (api *publicAPI) Hashrate() hexutil.Uint64 {
 	return 0
 }
 
-func (api *publicAPI) Syncing(_ context.Context) (interface{}, error) {
+func (api *publicAPI) Syncing(_ context.Context) (any, error) {
 	logger := api.Logger.With("method", "eth_syncing")
 	logger.Debug("request")
 

--- a/rpc/eth/metrics/api.go
+++ b/rpc/eth/metrics/api.go
@@ -211,7 +211,7 @@ func (m *metricsWrapper) GetBalance(ctx context.Context, address common.Address,
 }
 
 // GetBlockByHash implements eth.API.
-func (m *metricsWrapper) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (res map[string]interface{}, err error) {
+func (m *metricsWrapper) GetBlockByHash(ctx context.Context, blockHash common.Hash, fullTx bool) (res map[string]any, err error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_getBlockByHash")
 	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
 
@@ -220,7 +220,7 @@ func (m *metricsWrapper) GetBlockByHash(ctx context.Context, blockHash common.Ha
 }
 
 // GetBlockByNumber implements eth.API.
-func (m *metricsWrapper) GetBlockByNumber(ctx context.Context, blockNum ethrpc.BlockNumber, fullTx bool) (res map[string]interface{}, err error) {
+func (m *metricsWrapper) GetBlockByNumber(ctx context.Context, blockNum ethrpc.BlockNumber, fullTx bool) (res map[string]any, err error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_getBlockByNumber")
 	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
 
@@ -335,7 +335,7 @@ func (m *metricsWrapper) GetTransactionCount(ctx context.Context, ethAddr common
 }
 
 // GetTransactionReceipt implements eth.API.
-func (m *metricsWrapper) GetTransactionReceipt(ctx context.Context, txHash common.Hash) (res map[string]interface{}, err error) {
+func (m *metricsWrapper) GetTransactionReceipt(ctx context.Context, txHash common.Hash) (res map[string]any, err error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_getTransactionReceipt")
 	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
 
@@ -369,7 +369,7 @@ func (m *metricsWrapper) SendRawTransaction(ctx context.Context, data hexutil.By
 }
 
 // Syncing implements eth.API.
-func (m *metricsWrapper) Syncing(ctx context.Context) (res interface{}, err error) {
+func (m *metricsWrapper) Syncing(ctx context.Context) (res any, err error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("eth_syncing")
 	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
 

--- a/rpc/eth/revert_errors.go
+++ b/rpc/eth/revert_errors.go
@@ -25,7 +25,7 @@ type revertError struct {
 }
 
 // ErrorData returns the hex encoded error reason.
-func (e *revertError) ErrorData() interface{} {
+func (e *revertError) ErrorData() any {
 	return e.reason
 }
 

--- a/rpc/txpool/api.go
+++ b/rpc/txpool/api.go
@@ -4,7 +4,7 @@ package txpool
 // API is the txpool_ prefixed set of APIs in the Web3 JSON-RPC spec.
 type API interface {
 	// Content returns the (always empty) contents of the txpool.
-	Content() (map[string][]interface{}, error)
+	Content() (map[string][]any, error)
 }
 
 type publicAPI struct{}
@@ -14,8 +14,8 @@ func NewPublicAPI() API {
 	return &publicAPI{}
 }
 
-func (api *publicAPI) Content() (map[string][]interface{}, error) {
-	m := make(map[string][]interface{})
-	m["pending"] = []interface{}{}
+func (api *publicAPI) Content() (map[string][]any, error) {
+	m := make(map[string][]any)
+	m["pending"] = []any{}
 	return m, nil
 }

--- a/rpc/txpool/metrics.go
+++ b/rpc/txpool/metrics.go
@@ -7,7 +7,7 @@ type metricsWrapper struct {
 }
 
 // Content implements API.
-func (m *metricsWrapper) Content() (res map[string][]interface{}, err error) {
+func (m *metricsWrapper) Content() (res map[string][]any, err error) {
 	r, s, f, i, d := metrics.GetAPIMethodMetrics("txpool_content")
 	defer metrics.InstrumentCaller(r, s, f, i, d, &err)()
 

--- a/rpc/utils/utils.go
+++ b/rpc/utils/utils.go
@@ -70,8 +70,8 @@ func NewRPCTransaction(dbTx *model.Transaction) *RPCTransaction {
 }
 
 // ConvertToEthBlock converts block in db to rpc response format of a block.
-func ConvertToEthBlock(block *model.Block, fullTx bool) map[string]interface{} {
-	transactions := []interface{}{}
+func ConvertToEthBlock(block *model.Block, fullTx bool) map[string]any {
+	transactions := []any{}
 	for _, dbTx := range block.Transactions {
 		tx := NewRPCTransaction(dbTx)
 		if fullTx {
@@ -84,7 +84,7 @@ func ConvertToEthBlock(block *model.Block, fullTx bool) map[string]interface{} {
 	header := DB2EthHeader(block)
 	serialized := cbor.Marshal(block)
 
-	res := map[string]interface{}{
+	res := map[string]any{
 		"parentHash":       header.ParentHash,
 		"sha3Uncles":       header.UncleHash,
 		"miner":            header.Coinbase,

--- a/source/pebble/pebble.go
+++ b/source/pebble/pebble.go
@@ -17,8 +17,8 @@ import (
 
 var _ source.NodeSource = (*Source)(nil)
 
-func makeKey(method string, params ...interface{}) []byte {
-	return cbor.Marshal([]interface{}{method, params})
+func makeKey(method string, params ...any) []byte {
+	return cbor.Marshal([]any{method, params})
 }
 
 // Source is a pebble backend source.

--- a/storage/psql/metrics.go
+++ b/storage/psql/metrics.go
@@ -23,7 +23,7 @@ func measureDuration(label string) func() {
 	}
 }
 
-func getTypeName(t interface{}) string {
+func getTypeName(t any) string {
 	return reflect.TypeOf(t).String()
 }
 
@@ -32,7 +32,7 @@ type metricsWrapper struct {
 }
 
 // Delete implements storage.Storage.
-func (m *metricsWrapper) Delete(ctx context.Context, table interface{}, round uint64) error {
+func (m *metricsWrapper) Delete(ctx context.Context, table any, round uint64) error {
 	defer measureDuration(fmt.Sprintf("Delete(%s)", getTypeName(table)))()
 
 	return m.s.Delete(ctx, table, round)
@@ -137,14 +137,14 @@ func (m *metricsWrapper) GetTransactionReceipt(ctx context.Context, txHash strin
 }
 
 // Insert implements storage.Storage.
-func (m *metricsWrapper) Insert(ctx context.Context, value interface{}) error {
+func (m *metricsWrapper) Insert(ctx context.Context, value any) error {
 	defer measureDuration(fmt.Sprintf("Insert(%s)", getTypeName(value)))()
 
 	return m.s.Insert(ctx, value)
 }
 
 // InsertIfNotExists implements storage.Storage.
-func (m *metricsWrapper) InsertIfNotExists(ctx context.Context, value interface{}) error {
+func (m *metricsWrapper) InsertIfNotExists(ctx context.Context, value any) error {
 	defer measureDuration(fmt.Sprintf("InsertIfNotExists(%s)", getTypeName(value)))()
 
 	return m.s.InsertIfNotExists(ctx, value)
@@ -169,7 +169,7 @@ func (m *metricsWrapper) RunInTransaction(ctx context.Context, fn func(storage.S
 }
 
 // Upsert implements storage.Storage.
-func (m *metricsWrapper) Upsert(ctx context.Context, value interface{}) error {
+func (m *metricsWrapper) Upsert(ctx context.Context, value any) error {
 	defer measureDuration(fmt.Sprintf("Upsert(%s)", getTypeName(value)))()
 
 	return m.s.Upsert(ctx, value)

--- a/storage/psql/psql.go
+++ b/storage/psql/psql.go
@@ -75,7 +75,7 @@ func InitDB(
 	// advisory rather than something that is securely enforced.
 	if readOnly {
 		opts = append(opts, pgdriver.WithConnParams(
-			map[string]interface{}{
+			map[string]any{
 				"default_transaction_read_only": "on",
 			},
 		))
@@ -120,9 +120,9 @@ func (db *PostDB) GetTransaction(ctx context.Context, hash string) (*model.Trans
 }
 
 // Inserts a single record in the DB.
-func (db *PostDB) Insert(ctx context.Context, value interface{}) error {
+func (db *PostDB) Insert(ctx context.Context, value any) error {
 	switch values := value.(type) {
-	case []interface{}:
+	case []any:
 		for v := range values {
 			if _, err := db.DB.NewInsert().
 				Model(v).
@@ -130,7 +130,7 @@ func (db *PostDB) Insert(ctx context.Context, value interface{}) error {
 				return err
 			}
 		}
-	case interface{}:
+	case any:
 		_, err := db.DB.NewInsert().
 			Model(value).
 			Exec(ctx)
@@ -139,7 +139,7 @@ func (db *PostDB) Insert(ctx context.Context, value interface{}) error {
 	return nil
 }
 
-func (db *PostDB) insertSingle(ctx context.Context, value interface{}, upsert bool) error {
+func (db *PostDB) insertSingle(ctx context.Context, value any, upsert bool) error {
 	typ := reflect.TypeOf(value)
 	table := db.DB.Dialect().Tables().Get(typ)
 	pks := make([]string, len(table.PKs))
@@ -164,37 +164,37 @@ func (db *PostDB) insertSingle(ctx context.Context, value interface{}, upsert bo
 }
 
 // InsertIfNotExists inserts the record if it does not yet exist.
-func (db *PostDB) InsertIfNotExists(ctx context.Context, value interface{}) error {
+func (db *PostDB) InsertIfNotExists(ctx context.Context, value any) error {
 	switch values := value.(type) {
-	case []interface{}:
+	case []any:
 		for v := range values {
 			if err := db.insertSingle(ctx, v, false); err != nil {
 				return err
 			}
 		}
-	case interface{}:
+	case any:
 		return db.insertSingle(ctx, value, false)
 	}
 	return nil
 }
 
 // Upsert upserts the record.
-func (db *PostDB) Upsert(ctx context.Context, value interface{}) error {
+func (db *PostDB) Upsert(ctx context.Context, value any) error {
 	switch values := value.(type) {
-	case []interface{}:
+	case []any:
 		for v := range values {
 			if err := db.insertSingle(ctx, v, true); err != nil {
 				return err
 			}
 		}
-	case interface{}:
+	case any:
 		return db.insertSingle(ctx, value, true)
 	}
 	return nil
 }
 
 // Delete deletes all records with round less than the given round.
-func (db *PostDB) Delete(ctx context.Context, table interface{}, round uint64) error {
+func (db *PostDB) Delete(ctx context.Context, table any, round uint64) error {
 	_, err := db.DB.NewDelete().Model(table).Where("round < ?", round).Exec(ctx)
 	return err
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -14,16 +14,16 @@ var ErrNoRoundsIndexed = fmt.Errorf("no rounds indexed")
 
 type Storage interface {
 	// Insert inserts a record. On conflict the insert errors.
-	Insert(ctx context.Context, value interface{}) error
+	Insert(ctx context.Context, value any) error
 
 	// InsertIfNotExists inserts a record if a record with same primary key does not exist.
-	InsertIfNotExists(ctx context.Context, value interface{}) error
+	InsertIfNotExists(ctx context.Context, value any) error
 
 	// Upsert upserts a record.
-	Upsert(ctx context.Context, value interface{}) error
+	Upsert(ctx context.Context, value any) error
 
 	// Delete deletes all records with round less than the given round.
-	Delete(ctx context.Context, table interface{}, round uint64) error
+	Delete(ctx context.Context, table any, round uint64) error
 
 	// GetBlockRound returns block round by block hash.
 	GetBlockRound(ctx context.Context, hash string) (uint64, error)

--- a/tests/e2e_regression/inspect_cache.go
+++ b/tests/e2e_regression/inspect_cache.go
@@ -36,7 +36,7 @@ func main() {
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := iter.Key()
-		var decoded []interface{}
+		var decoded []any
 		if err := cbor.Unmarshal(key, &decoded); err == nil {
 			if len(decoded) > 0 {
 				method := fmt.Sprintf("%v", decoded[0])
@@ -44,7 +44,7 @@ func main() {
 				if method == "CoreMinGasPrice" {
 					minGasPriceCount++
 					if len(decoded) > 1 {
-						if params, ok := decoded[1].([]interface{}); ok && len(params) > 0 {
+						if params, ok := decoded[1].([]any); ok && len(params) > 0 {
 							if round, ok := params[0].(uint64); ok {
 								minGasPriceRounds[round] = true
 							}

--- a/tests/rpc/utils.go
+++ b/tests/rpc/utils.go
@@ -40,16 +40,16 @@ import (
 )
 
 type Request struct {
-	Version string      `json:"jsonrpc"`
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params"`
-	ID      int         `json:"id"`
+	Version string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params"`
+	ID      int    `json:"id"`
 }
 
 type Error struct {
-	Code    int         `json:"code"`
-	Message string      `json:"message"`
-	Data    interface{} `json:"data,omitempty"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
 }
 
 type Response struct {


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.