### PR TITLE
docker: Add rofl-appd-localnet

### DIFF
--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -183,7 +183,7 @@ function populate_accounts() {
     IFS=","
     for addr in ${TO};
     do
-      ${OASIS_CLI_BINARY} account deposit ${AMOUNT} ${addr} --account test:alice --gas-price 0 -y > /dev/null
+      ${OASIS_CLI_BINARY} account deposit ${AMOUNT} ${addr} --account test:alice --gas-price 0 -y > /dev/null 2>&1
     done
     IFS=" "
   elif [[ ${TO} =~ [[:space:]] ]]; then
@@ -191,8 +191,8 @@ function populate_accounts() {
     for n in $(seq 0 $((N-1)))
     do
       acct="account$n"
-      ${OASIS_CLI_BINARY} wallet import ${acct} --algorithm secp256k1-bip44 --number ${n} --secret "${TO}" -y > /dev/null
-      ${OASIS_CLI_BINARY} account deposit ${AMOUNT} ${acct} --account test:alice --gas-price 0 -y > /dev/null
+      ${OASIS_CLI_BINARY} wallet import ${acct} --algorithm secp256k1-bip44 --number ${n} --secret "${TO}" -y > /dev/null 2>&1
+      ${OASIS_CLI_BINARY} account deposit ${AMOUNT} ${acct} --account test:alice --gas-price 0 -y > /dev/null 2>&1
     done
 
     ACCT_OUT=""
@@ -203,7 +203,7 @@ function populate_accounts() {
 
       # Parse Ethereum address and private key from output.
       IFS="#"
-      out=$(${OASIS_CLI_BINARY} wallet export ${acct} -y)
+      out=$(${OASIS_CLI_BINARY} wallet export ${acct} -y 2>/dev/null)
       eth_addr=$(echo "${out}" | grep -e '^Ethereum address:' | cut -d':' -f2 | awk '{$1=$1};1')
       pk=$(echo "${out}" | tail -1)
       IFS=" "
@@ -431,20 +431,20 @@ if [ ! -z "${ROFL_BINARY:-}" ]; then
 
   echo
   notice "Configuring ROFL ${ROFLS[0]}:\n"
-  ${OASIS_CLI_BINARY} account deposit ${ROFL_ADMIN_FUND} ${ROFL_ADMIN} --account test:alice --gas-price 0 -y >/dev/null
+  ${OASIS_CLI_BINARY} account deposit ${ROFL_ADMIN_FUND} ${ROFL_ADMIN} --account test:alice --gas-price 0 -y > /dev/null 2>&1
   printf "   ROFL admin ${CYAN}${ROFL_ADMIN}${OFF} funded ${ROFL_ADMIN_FUND} TEST\n"
 
-  ${OASIS_CLI_BINARY} account deposit ${COMPUTE_NODE_FUND} ${COMPUTE_NODE_ADDRESS} --account test:alice --gas-price 0 -y >/dev/null
+  ${OASIS_CLI_BINARY} account deposit ${COMPUTE_NODE_FUND} ${COMPUTE_NODE_ADDRESS} --account test:alice --gas-price 0 -y > /dev/null 2>&1
   printf "   Compute node ${CYAN}${COMPUTE_NODE_ADDRESS}${OFF} funded ${COMPUTE_NODE_FUND} TEST\n"
 
   # XXX: Report ROFL app ID in JSON and properly parse it.
-  ${OASIS_CLI_BINARY} rofl init --tee sgx --kind raw >/dev/null
-  ROFL_APP_ID=$(${OASIS_CLI_BINARY} rofl create --account ${ROFL_ADMIN} --network localnet -y | grep "Created ROFL app" | rev | cut -d' ' -f1 | rev)
+  ${OASIS_CLI_BINARY} rofl init --tee sgx --kind raw > /dev/null 2>&1
+  ROFL_APP_ID=$(${OASIS_CLI_BINARY} rofl create --account ${ROFL_ADMIN} --network localnet -y 2>/dev/null | grep "Created ROFL app" | rev | cut -d' ' -f1 | rev)
   printf "   App ID: ${CYAN}${ROFL_APP_ID}${OFF}\n"
 
   # Submit the hardcoded enclave ID to the chain.
   sed -i "s@      enclaves: \[\]@      enclaves:\n        - id: ${ROFL_ENCLAVE_ID}@" ${ROFL_MANIFEST_PATH}
-  ${OASIS_CLI_BINARY} rofl update -y >/dev/null
+  ${OASIS_CLI_BINARY} rofl update -y > /dev/null 2>&1
   printf "   Enclave ID: ${CYAN}${ROFL_ENCLAVE_ID}${OFF}\n"
 fi
 

--- a/docker/common/start.sh
+++ b/docker/common/start.sh
@@ -246,17 +246,26 @@ function populate_accounts() {
 T_START="$(date +%s)"
 
 if [[ "${PARATIME_NAME}" == "sapphire" ]]; then
-  ROFLS=($(ls /rofls/*.orc 2>/dev/null || exit 0))
-  if [[ ${#ROFLS[@]} -eq 0 ]]; then
+  if [ ! -f "/rofls/rofl.yaml" ]; then
     notice "No ROFLs detected.\n"
   else
+    TEE=$(yq -r .tee /rofls/rofl.yaml)
+    if [[ "${TEE}" == "tdx" ]]; then
+      ROFLS=("/rofl-appd-localnet.localnet.orc")
+      notice "TDX ROFL detected. Localnet appd service will be accessible on the host via rofl-appd.sock in the shared volume\n"
+    elif [[ "${TEE}" == "sgx" ]]; then
+      ROFLS=($(ls /rofls/*.orc 2>/dev/null || exit 0))
+      notice "Detected SGX ROFL bundle: ${ROFLS[0]}\n"
+    else
+      notice "Invalid tee kind in rofl.yaml: ${TEE}. Aborting.\n"
+      exit -1
+    fi
     unzip -q "${ROFLS[0]}" "app.elf"
     mv "app.elf" "rofl.elf"
     # Create a dummy, non-empty SGXS for mock sgx.
     echo "dummy" > "rofl.sgxs"
     export ROFL_BINARY="/rofl.elf"
     export ROFL_BINARY_SGXS="/rofl.sgxs"
-    notice "Detected ROFL bundle: ${ROFLS[0]}\n"
   fi
 fi
 

--- a/docker/emerald-localnet/Dockerfile
+++ b/docker/emerald-localnet/Dockerfile
@@ -7,9 +7,9 @@ RUN cd oasis-web3-gateway && make && strip -S -x oasis-web3-gateway
 FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.6.x AS oasis-core-dev
 
 # Set _BRANCH to build from source; comment it out to use the pre-built release.
-ARG OASIS_CORE_VERSION=25.6
+#ARG OASIS_CORE_VERSION=25.9
 ARG OASIS_CORE_BRANCH=master
-ARG OASIS_CLI_VERSION=0.18.5
+#ARG OASIS_CLI_VERSION=0.18.5
 ARG OASIS_CLI_BRANCH=master
 
 ARG NEXUS_VERSION=0.7.17

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -11,10 +11,10 @@ ARG PARATIME_NAME
 # variant.
 # Note that the simple keymanager is always freshly built because we need to
 # specify different build options from what is in the release version.
-ARG OASIS_CORE_SIMPLE_KM_BRANCH=stable/25.6.x
-ARG OASIS_CORE_VERSION=25.6
+ARG OASIS_CORE_SIMPLE_KM_BRANCH=master
+#ARG OASIS_CORE_VERSION=25.6
 ARG OASIS_CORE_BRANCH=master
-ARG OASIS_CLI_VERSION=0.18.5
+#ARG OASIS_CLI_VERSION=0.18.5
 ARG OASIS_CLI_BRANCH=master
 ARG OASIS_WEB3_GATEWAY_BRANCH=v5.3.4
 #ARG OASIS_WEB3_GATEWAY_VERSION=main
@@ -39,10 +39,8 @@ RUN set -e; \
     \
     && cd / \
     && if [ "x${OASIS_CORE_BRANCH}" != "x" ]; then \
-        git clone https://github.com/oasisprotocol/oasis-core.git --depth 1 \
+        git clone https://github.com/oasisprotocol/oasis-core.git --branch ${OASIS_CORE_BRANCH} --depth 1 \
         && cd /oasis-core \
-        && git fetch origin ${OASIS_CORE_BRANCH} --depth 1 \
-        && git checkout FETCH_HEAD \
         && make -C go oasis-node oasis-net-runner \
         && strip -s /oasis-core/go/oasis-net-runner/oasis-net-runner /oasis-core/go/oasis-node/oasis-node \
         && mv /oasis-core/go/oasis-net-runner/oasis-net-runner /oasis-core/go/oasis-node/oasis-node /out \
@@ -57,10 +55,8 @@ RUN set -e; \
     \
     && cd / \
     && if [ "x${OASIS_CLI_BRANCH}" != "x" ]; then \
-        git clone https://github.com/oasisprotocol/cli.git --depth 1 \
+        git clone https://github.com/oasisprotocol/cli.git --branch ${OASIS_CLI_BRANCH} --depth 1 \
         && cd /cli \
-        && git fetch origin ${OASIS_CLI_BRANCH} --depth 1 \
-        && git checkout FETCH_HEAD \
         && make CGO_ENABLED=0 \
         && strip -s oasis \
         && mv oasis /out \
@@ -75,10 +71,8 @@ RUN set -e; \
     \
     && cd / \
     && if [ "x${OASIS_WEB3_GATEWAY_BRANCH}" != "x" ]; then \
-        git clone https://github.com/oasisprotocol/oasis-web3-gateway.git oasis-web3-gateway-git --depth 1 \
+        git clone https://github.com/oasisprotocol/oasis-web3-gateway.git oasis-web3-gateway-git --branch ${OASIS_WEB3_GATEWAY_BRANCH} --depth 1 \
         && cd /oasis-web3-gateway-git \
-        && git fetch origin ${OASIS_WEB3_GATEWAY_BRANCH} --depth 1 \
-        && git checkout FETCH_HEAD \
         && make \
         && strip -s oasis-web3-gateway \
         && mv oasis-web3-gateway /out \
@@ -93,16 +87,14 @@ RUN set -e; \
     \
     && cd / \
     && if [ "x${OASIS_SAPPHIRE_PARATIME_BRANCH}" != "x" ]; then \
-        git clone https://github.com/oasisprotocol/sapphire-paratime.git sapphire-paratime-git --depth 1 \
+        git clone https://github.com/oasisprotocol/sapphire-paratime.git sapphire-paratime-git --branch ${OASIS_SAPPHIRE_PARATIME_BRANCH} --depth 1 \
         && cd /sapphire-paratime-git \
-        && git fetch origin ${OASIS_SAPPHIRE_PARATIME_BRANCH} --depth 1 \
-        && git checkout FETCH_HEAD \
         && cd runtime \
         && OASIS_UNSAFE_SKIP_AVR_VERIFY=1 OASIS_UNSAFE_ALLOW_DEBUG_ENCLAVES=1 OASIS_UNSAFE_USE_LOCALNET_CHAINID=1 \
         cargo build --release --locked --features debug-mock-sgx \
         && strip -s /sapphire-paratime-git/runtime/target/release/sapphire-paratime \
         && mv /sapphire-paratime-git/runtime/target/release/sapphire-paratime /out/ronl.elf \
-        && rm -rf sapphire-paratime-git; \
+        && rm -rf /sapphire-paratime-git; \
     else \
         wget https://github.com/oasisprotocol/${PARATIME_NAME}-paratime/releases/download/v${PARATIME_VERSION}/localnet-${PARATIME_NAME}-paratime.orc \
         && unzip "localnet-${PARATIME_NAME}-paratime.orc" ronl.elf \

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -19,6 +19,8 @@ ARG OASIS_CLI_BRANCH=master
 ARG OASIS_WEB3_GATEWAY_BRANCH=v5.3.4
 #ARG OASIS_WEB3_GATEWAY_VERSION=main
 #ARG OASIS_SAPPHIRE_PARATIME_BRANCH=main
+ARG OASIS_ROFL_APPD_LOCALNET_VERSION=0.1.0
+#ARG OASIS_ROFL_APPD_LOCALNET_BRANCH=main
 
 ARG NEXUS_VERSION=0.7.17
 # ARG NEXUS_BRANCH=main
@@ -104,6 +106,17 @@ RUN set -e; \
         && rm "localnet-${PARATIME_NAME}-paratime.orc"; \
     fi \
     \
+    && if [ "x${OASIS_ROFL_APPD_LOCALNET_BRANCH}" != "x" ]; then \
+        git clone https://github.com/oasisprotocol/oasis-sdk.git oasis-sdk-git --branch ${OASIS_ROFL_APPD_LOCALNET_BRANCH} --depth 1 \
+        && cd /oasis-sdk-git \
+        && cd rofl-appd-localnet \
+        && /out/oasis rofl build --offline \
+        && mv /oasis-sdk-git/rofl-appd-localnet/rofl-appd-localnet.localnet.orc /out/rofl-appd-localnet.localnet.orc \
+        && rm -rf /oasis-sdk-git; \
+    else \
+        wget -O /out/rofl-appd-localnet.localnet.orc https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-appd-localnet/v${OASIS_ROFL_APPD_LOCALNET_VERSION}/rofl-appd-localnet.localnet.orc; \
+    fi \
+    \
     && cd / \
     && if [ "x${NEXUS_BRANCH}" != "x" ]; then \
         git clone https://github.com/oasisprotocol/nexus.git nexus-git --depth 1 \
@@ -182,7 +195,7 @@ ENV GODEBUG=cpu.all=off
 
 ARG VERSION
 
-RUN apt update && apt install -y --no-install-recommends bash libseccomp2 jq curl ca-certificates unzip binutils file \
+RUN apt update && apt install -y --no-install-recommends bash libseccomp2 jq yq curl ca-certificates unzip binutils file \
     && su -c "POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres /usr/local/bin/docker-entrypoint.sh postgres &" postgres \
     # Explorer frontend deps.
     && apt install -y --no-install-recommends nginx \


### PR DESCRIPTION
This PR:
- enables testing of tdx-containers ROFLs on Localnet.
- fixes Oasis CLI prompts leftovers in sapphire-localnet and emerald-localnet bootstrap outputs
- simplifies Dockerfiles using `git --branch` parameter instead of fetch&checkout

Usage:

1. go to your ROFL directory that contains `rofl.yaml` of type `tee: tdx`
2. `docker run -it -p8544-8548:8544-8548 -v .:/rofls ghcr.io/oasisprotocol/sapphire-localnet:local`
3. `rofl-appd.sock` will become available in your folder. Use it to write integration tests for your ROFL.

Implements #711 

Requires https://github.com/oasisprotocol/oasis-sdk/pull/2430