### PR TITLE
docker: Bump Sapphire to 1.3.0-testnet

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -35,7 +35,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      OASIS_CORE_VERSION: "25.3"
+      OASIS_CORE_VERSION: "26.1"
       OASIS_NODE_BINARY: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER_BINARY: ${{ github.workspace }}/oasis_core/oasis-net-runner
       EMERALD_PARATIME_VERSION: 11.0.0-testnet
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
 
       - name: Install prerequisites
         run: |
@@ -107,14 +107,14 @@ jobs:
         ports:
           - 5432:5432
     env:
-      OASIS_CORE_VERSION: "25.6"
+      OASIS_CORE_VERSION: "26.1"
       OASIS_NODE_BINARY: ${{ github.workspace }}/oasis_core/oasis-node
       OASIS_NET_RUNNER_BINARY: ${{ github.workspace }}/oasis_core/oasis-net-runner
-      SAPPHIRE_PARATIME_VERSION: 1.1.2-testnet
+      SAPPHIRE_PARATIME_VERSION: 1.3.0-testnet
       GATEWAY__CHAIN_ID: 23293
       GATEWAY__OASIS_RPCS: true
       SAPPHIRE_PARATIME: ${{ github.workspace }}/oasis_core/sapphire-paratime
-      KEYMANAGER_ARTIFACT_URL: https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/16070/jobs/019a2725-f1f8-43a1-a7b0-615227854f17/artifacts/019a272c-0b96-4a18-85f1-115ffae35403 # Find this at https://buildkite.com/oasisprotocol/oasis-core-ci/builds?branch=stable%2F<...> under "Build runtimes": simple-keymanager.mocksgx.
+      KEYMANAGER_ARTIFACT_URL: https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/16925/jobs/019eab8c-67b9-43ba-8e59-1baa074dc808/artifacts/019eab90-0897-4358-bc40-4a002b8e5658 # Find this at https://buildkite.com/oasisprotocol/oasis-core-ci/builds?branch=stable%2F<...> under "Build runtimes": simple-keymanager.mocksgx.
       KEYMANAGER_BINARY: ${{ github.workspace }}/oasis_core/simple-keymanager
       OASIS_NODE_DATADIR: /tmp/eth-runtime-test
       OASIS_DOCKER_START_EXPLORER: no
@@ -125,7 +125,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
 
       - name: Install prerequisites
         run: |
@@ -197,7 +197,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
 
       - name: Build Go
         run: make oasis-web3-gateway

--- a/docker/sapphire-localnet/Dockerfile
+++ b/docker/sapphire-localnet/Dockerfile
@@ -1,4 +1,4 @@
-ARG PARATIME_VERSION=1.1.2-testnet
+ARG PARATIME_VERSION=1.3.0-testnet
 ARG PARATIME_NAME=sapphire
 
 FROM ghcr.io/oasisprotocol/oasis-core-dev:stable-25.6.x AS oasis-core-dev


### PR DESCRIPTION
Brings 64k contract size to sapphire-localnet.