### PR TITLE
fix(rpc/oasis): Tolerate transient health check failures

### DIFF
--- a/rpc/oasis/health.go
+++ b/rpc/oasis/health.go
@@ -13,6 +13,19 @@ import (
 const (
 	healthCheckInterval    = 30 * time.Second
 	healthIterationTimeout = 15 * time.Second
+
+	// healthRetryInterval is the interval between iterations while the previous one failed. It is
+	// shorter than healthCheckInterval so that a short-lived failure is confirmed or cleared
+	// quickly, both when going unhealthy and when recovering.
+	healthRetryInterval = 5 * time.Second
+
+	// healthUnhealthyThreshold is the number of consecutive failed iterations after which the
+	// service is reported as unhealthy. Querying the public key can fail for a short while (e.g.
+	// when the key manager is momentarily unreachable), and a single such failure should not take
+	// the gateway out of rotation. Since failing iterations are retried on healthRetryInterval,
+	// this tolerance delays reporting a genuine outage by roughly
+	// (healthUnhealthyThreshold-1)*healthRetryInterval.
+	healthUnhealthyThreshold = 3
 )
 
 type healthChecker struct {
@@ -21,6 +34,9 @@ type healthChecker struct {
 	logger *logging.Logger
 
 	health uint32
+
+	// failures is the number of consecutive failed iterations. Only accessed from the run goroutine.
+	failures uint
 }
 
 // Implements server.HealthCheck.
@@ -39,24 +55,52 @@ func (h *healthChecker) updateHealth(healthy bool) {
 	}
 }
 
+// recordResult folds the result of a single health check iteration into the health state.
+func (h *healthChecker) recordResult(err error) {
+	if err == nil {
+		h.failures = 0
+		h.logger.Debug("oasis_ RPC healthy")
+		h.updateHealth(true)
+		return
+	}
+
+	h.failures++
+	if h.failures < healthUnhealthyThreshold {
+		h.logger.Warn("failed to fetch public key, tolerating",
+			"err", err,
+			"failures", h.failures,
+			"threshold", healthUnhealthyThreshold,
+		)
+		return
+	}
+
+	h.logger.Error("failed to fetch public key",
+		"err", err,
+		"failures", h.failures,
+	)
+	h.updateHealth(false)
+}
+
+// nextInterval returns the delay before the next iteration. While iterations are failing the
+// checker probes more often, so that the failure is confirmed or cleared quickly.
+func (h *healthChecker) nextInterval() time.Duration {
+	if h.failures > 0 {
+		return healthRetryInterval
+	}
+	return healthCheckInterval
+}
+
 func (h *healthChecker) run() {
 	for {
 		select {
-		case <-time.After(healthCheckInterval):
+		case <-time.After(h.nextInterval()):
 			func() {
 				ctx, cancel := context.WithTimeout(h.ctx, healthIterationTimeout)
 				defer cancel()
 
 				// Query public keys.
 				_, err := h.source.CoreCallDataPublicKey(ctx)
-				if err != nil {
-					h.logger.Error("failed to fetch public key", "err", err)
-					h.updateHealth(false)
-					return
-				}
-
-				h.logger.Debug("oasis_ RPC healthy")
-				h.updateHealth(true)
+				h.recordResult(err)
 			}()
 		case <-h.ctx.Done():
 			h.updateHealth(false)

--- a/rpc/oasis/health_test.go
+++ b/rpc/oasis/health_test.go
@@ -1,0 +1,94 @@
+package oasis
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/logging"
+)
+
+// errKeyManager is a stand-in for the key manager failures that the health checker should tolerate.
+var errKeyManager = errors.New("key manager unavailable")
+
+func newTestHealthChecker() *healthChecker {
+	return &healthChecker{logger: logging.GetLogger("oasis_test")}
+}
+
+func TestHealthCheckerToleratesShortFailures(t *testing.T) {
+	require := require.New(t)
+
+	h := newTestHealthChecker()
+	h.recordResult(nil)
+	require.NoError(h.Health(), "should be healthy after a successful iteration")
+
+	// Fewer than healthUnhealthyThreshold consecutive failures must not flip the health state.
+	for i := 1; i < healthUnhealthyThreshold; i++ {
+		h.recordResult(errKeyManager)
+		require.NoError(h.Health(), "should still be healthy after %d consecutive failures", i)
+	}
+
+	// A success in between clears the counter.
+	h.recordResult(nil)
+	require.NoError(h.Health(), "should be healthy after recovering")
+
+	for i := 1; i < healthUnhealthyThreshold; i++ {
+		h.recordResult(errKeyManager)
+		require.NoError(h.Health(), "counter should have been reset by the successful iteration")
+	}
+}
+
+func TestHealthCheckerReportsSustainedFailures(t *testing.T) {
+	require := require.New(t)
+
+	h := newTestHealthChecker()
+	h.recordResult(nil)
+
+	for range healthUnhealthyThreshold {
+		h.recordResult(errKeyManager)
+	}
+	require.Error(h.Health(), "should be unhealthy after reaching the threshold")
+
+	// Every further failure keeps it unhealthy.
+	h.recordResult(errKeyManager)
+	require.Error(h.Health(), "should stay unhealthy while failures continue")
+
+	// A single success is enough to recover.
+	h.recordResult(nil)
+	require.NoError(h.Health(), "should recover on the first successful iteration")
+}
+
+func TestHealthCheckerRetriesFasterWhileFailing(t *testing.T) {
+	require := require.New(t)
+
+	h := newTestHealthChecker()
+	h.recordResult(nil)
+	require.Equal(healthCheckInterval, h.nextInterval(), "should use the normal interval while healthy")
+
+	// Probe more often from the very first failure, so that it is confirmed or cleared quickly.
+	h.recordResult(errKeyManager)
+	require.Equal(healthRetryInterval, h.nextInterval(), "should retry faster after a failure")
+
+	for range healthUnhealthyThreshold {
+		h.recordResult(errKeyManager)
+	}
+	require.Error(h.Health())
+	require.Equal(healthRetryInterval, h.nextInterval(), "should keep retrying faster while unhealthy")
+
+	h.recordResult(nil)
+	require.Equal(healthCheckInterval, h.nextInterval(), "should return to the normal interval once recovered")
+}
+
+func TestHealthCheckerUnhealthyUntilFirstSuccess(t *testing.T) {
+	require := require.New(t)
+
+	h := newTestHealthChecker()
+	require.Error(h.Health(), "should be unhealthy before the first iteration")
+
+	h.recordResult(errKeyManager)
+	require.Error(h.Health(), "should stay unhealthy while it has never been healthy")
+
+	h.recordResult(nil)
+	require.NoError(h.Health(), "should become healthy after the first successful iteration")
+}


### PR DESCRIPTION
The `oasis_` health check flips to unhealthy on a single failed `callDataPublicKey` query, so a momentary key manager blip takes the gateway out of rotation for at least one interval.

- Require 3 consecutive failures before reporting unhealthy.
- Retry on a shorter interval (5s) while iterations are failing, so a failure is confirmed or cleared quickly and a recovery is picked up within seconds.

Includes unit tests for the threshold, the retry interval and the initial state.
